### PR TITLE
Wizard fixes for v1.3

### DIFF
--- a/odmlui/EditorTab.py
+++ b/odmlui/EditorTab.py
@@ -53,7 +53,7 @@ class EditorTab(object):
         file_path = uri_to_path(uri)
         parser = get_parser_for_uri(file_path)
         odml_reader = ODMLReader(parser=parser)
-        self.document = odml_reader.fromFile(open(file_path))
+        self.document = odml_reader.from_file(open(file_path))
 
         self.document.finalize()
         self.window.registry.add(self.document)

--- a/odmlui/Wizard.py
+++ b/odmlui/Wizard.py
@@ -242,7 +242,8 @@ class DocumentWizard:
                 for prop in sec.properties:
                     newsec.append(prop.clone())
                 sec._assoc_sec = newsec
-                sec.parent._assoc_sec.append(newsec)
+                if hasattr(sec.parent, "_assoc_sec"):
+                    sec.parent._assoc_sec.append(newsec)
 
         self.finish(doc)
 

--- a/odmlui/Wizard.py
+++ b/odmlui/Wizard.py
@@ -233,15 +233,16 @@ class DocumentWizard:
 
         # copy all selected sections from the terminology
         term = self.section_page.term
-        term._assoc_sec = doc # set the associated section
-        for sec in term.itersections(recursive=True):
-            if not sec in self.section_page.sections:
-                continue
-            newsec = sec.clone(children=False)
-            for prop in sec.properties:
-                newsec.append(prop.clone())
-            sec._assoc_sec = newsec
-            sec.parent._assoc_sec.append(newsec)
+        if term:
+            term._assoc_sec = doc # set the associated section
+            for sec in term.itersections(recursive=True):
+                if not sec in self.section_page.sections:
+                    continue
+                newsec = sec.clone(children=False)
+                for prop in sec.properties:
+                    newsec.append(prop.clone())
+                sec._assoc_sec = newsec
+                sec.parent._assoc_sec.append(newsec)
 
         self.finish(doc)
 
@@ -251,6 +252,7 @@ class DocumentWizard:
         """
         raise NotImplementedError
 
-if __name__=="__main__":
+
+if __name__ == "__main__":
     DocumentWizard()
     gtk.main()


### PR DESCRIPTION
- Fixes odmlreader.fromFile -> from_file incompatibility with python odml 1.3.2
- Fixes Wizard crash on empty repository and empty parent section attribute.