### PR TITLE
Catching up with core 1.3 (and even more fixes)

### DIFF
--- a/odmlui/Editor.py
+++ b/odmlui/Editor.py
@@ -404,11 +404,7 @@ class EditorWindow(gtk.Window):
         if path == "#new":
             self.new_file()
         elif path is not None:
-            try:
-                self.load_document(path)
-            except Exception as e:
-                ErrorDialog(self, "Error while parsing '%s'" % uri_to_path(path), str(e))
-                self.welcome()
+            self.load_document(path)
 
         return True
 
@@ -457,7 +453,10 @@ class EditorWindow(gtk.Window):
     def load_document(self, uri, file_type=None):
         """open a new tab, load the document into it"""
         tab = EditorTab(self)
-        tab.load(uri)
+
+        if not tab.load(uri):
+            return
+
         self.append_tab(tab)
         return tab
 

--- a/odmlui/EditorTab.py
+++ b/odmlui/EditorTab.py
@@ -12,9 +12,10 @@ import odml.validation
 from odml.tools.odmlparser import ODMLReader, ODMLWriter, allowed_parsers
 
 from .CommandManager import CommandManager
-from .ValidationWindow import ValidationWindow
 from .Helpers import uri_to_path, get_parser_for_uri, get_extension, \
     get_parser_for_file_type
+from .MessageDialog import ErrorDialog
+from .ValidationWindow import ValidationWindow
 
 
 class EditorTab(object):
@@ -54,7 +55,13 @@ class EditorTab(object):
         file_path = uri_to_path(uri)
         parser = get_parser_for_uri(file_path)
         odml_reader = ODMLReader(parser=parser)
-        self.document = odml_reader.from_file(file_path)
+        try:
+            self.document = odml_reader.from_file(file_path)
+        except Exception as e:
+            ErrorDialog(self.window, "Error parsing '%s'" % file_path, str(e))
+            if len(self.window.notebook) < 1:
+                self.window.welcome()
+            return False
 
         self.document.finalize()
         self.window.registry.add(self.document)

--- a/odmlui/EditorTab.py
+++ b/odmlui/EditorTab.py
@@ -54,7 +54,7 @@ class EditorTab(object):
         file_path = uri_to_path(uri)
         parser = get_parser_for_uri(file_path)
         odml_reader = ODMLReader(parser=parser)
-        self.document = odml_reader.from_file(open(file_path))
+        self.document = odml_reader.from_file(file_path)
 
         self.document.finalize()
         self.window.registry.add(self.document)

--- a/odmlui/PropertyView.py
+++ b/odmlui/PropertyView.py
@@ -182,6 +182,13 @@ class PropertyView(TerminologyPopupTreeView):
 
             # first row edit event for the value, so switch the object
             if column_name != "name" and first_row:
+                # Add empty value if value list is empty.
+                if len(prop.values) < 1:
+                    cmd = commands.AppendValue(obj=prop, val=odml.Value(""))
+                    self.execute(cmd)
+                    # Force reset view model to keep up to date with changed tree model.
+                    self.model = PropertyModel.PropertyModel(section)
+
                 prop = prop.values[0]
             if not (column_name == "name" and first_row):
                 column_name = [column_name, "value"] # backup the value attribute too

--- a/odmlui/treemodel/TreeIters.py
+++ b/odmlui/treemodel/TreeIters.py
@@ -59,7 +59,7 @@ class ValueIter(GenericIter.GenericIter):
             value = self._obj.get_display()
 
             # If the value is an empty string, render a placeholder text.
-            if not value or value == '':
+            if not value:
                 value = '<i>n/a</i>'
             else:
                 # Some issues with the rendering of `unicode` in Python 2 directly

--- a/odmlui/treemodel/TreeIters.py
+++ b/odmlui/treemodel/TreeIters.py
@@ -58,18 +58,18 @@ class ValueIter(GenericIter.GenericIter):
         if attr == "value":
             value = self._obj.get_display()
 
-            # Some issues with the rendering of `unicode` in Python 2 directly
-            # to Tree Column cell renderer. Hence, first encode it here.
-            if ValueIter.is_python2:
-                value = value.encode('utf-8')
-
-            # Always escape "&" and "<" since they break assigning values containing
-            # these characters.
-            value = value.replace("&", "&amp;").replace("<", "&lt;")
-
             # If the value is an empty string, render a placeholder text.
-            if value == '':
+            if not value or value == '':
                 value = '<i>n/a</i>'
+            else:
+                # Some issues with the rendering of `unicode` in Python 2 directly
+                # to Tree Column cell renderer. Hence, first encode it here.
+                if ValueIter.is_python2:
+                    value = value.encode('utf-8')
+
+                # Always escape "&" and "<" since they break assigning values containing
+                # these characters.
+                value = value.replace("&", "&amp;").replace("<", "&lt;")
 
             return value
 


### PR DESCRIPTION
This PR addresses the one relevant change made in the python-odml 1.3 branch.

It also
- Fixes if a Property without a Value object is encountered. Unresolved this leads to a state where no value can be added to the particular Property.
- Fixes missing notification window, when a file opening via ctrl-o fails.
- Fixes TreeIter background errors on empty values.