### PR TITLE
Final fixes and improvements for release 1.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,16 +45,30 @@ matrix:
     - os: osx
       language: generic
       env:
-        - OSXENV=2.7
-        - CONDA=Y
-        - CONDAPY=2.7
-
-    - os: osx
-      language: generic
-      env:
         - OSXENV=3.5
         - CONDA=Y
         - CONDAPY=3.5
+
+#    Keep only one osx branch active for now
+#    since currently osx builds on travis
+#    are frequently stalled or indefinitely delayed.
+#    - os: osx
+#      language: generic
+#      env:
+#        - OSXENV=2.7
+#        - CONDA=Y
+#        - CONDAPY=2.7
+#    - os: osx
+#      language: generic
+#      env:
+#        - OSXENV=2.7
+#        - CONDA=N
+#    - os: osx
+#      language: generic
+#      env:
+#        - OSXENV=3.5
+#        - CONDA=N
+
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then bash resources/install_osx_virtualenv.sh; fi

--- a/odmlui/Editor.py
+++ b/odmlui/Editor.py
@@ -297,7 +297,7 @@ class EditorWindow(gtk.Window):
 
         vpaned = gtk.VPaned()
         vpaned.show()
-        vpaned.set_position(350)
+        vpaned.set_position(290)
         vpaned.pack1(hpaned, resize=True, shrink=False)
         vpaned.pack2(frame, resize=False, shrink=True)
 

--- a/odmlui/Editor.py
+++ b/odmlui/Editor.py
@@ -184,6 +184,13 @@ class EditorWindow(gtk.Window):
         self.set_title("odML Editor")
         self.set_default_size(800, 600)
 
+        # Check available screen size and adjust default app size to 1024x768 if possible.
+        screen = self.get_screen()
+        currmon = screen.get_monitor_at_window(screen.get_active_window())
+        mondims = screen.get_monitor_geometry(currmon)
+        if mondims.width >= 1024 and mondims.height >= 768:
+            self.set_default_size(1024, 768)
+
         icons = load_icon_pixbufs("odml-logo")
         self.set_icon_list(icons)
 

--- a/odmlui/Editor.py
+++ b/odmlui/Editor.py
@@ -304,7 +304,9 @@ class EditorWindow(gtk.Window):
 
         vpaned = gtk.VPaned()
         vpaned.show()
-        vpaned.set_position(290)
+        # Adjust Attribute view position to default window size
+        vpaned.set_position(self.get_default_size().height - 315)
+
         vpaned.pack1(hpaned, resize=True, shrink=False)
         vpaned.pack2(frame, resize=False, shrink=True)
 

--- a/odmlui/Wizard.py
+++ b/odmlui/Wizard.py
@@ -12,7 +12,6 @@ from .ScrolledWindow import ScrolledWindow
 import odml
 import odml.terminology as terminology
 
-
 class Table(object):
     def __init__(self, cols):
         self.table = gtk.Table(rows=1, columns=cols)
@@ -61,17 +60,6 @@ class Page(gtk.VBox):
         called to finish processing the page and allow it to collect all entered data
         """
         pass
-
-
-class IntroPage(Page):
-    type = gtk.ASSISTANT_PAGE_INTRO
-    complete = True
-
-    def init(self):
-        label = gtk.Label("Welcome! This assistant will guide you trough the first " +
-                          "steps of creating a new odML-Document")
-        label.set_line_wrap(True)
-        self.pack_start(label, True, True, 0)
 
 
 def get_username():
@@ -203,21 +191,19 @@ class DocumentWizard:
         assistant = gtk.Assistant()
 
         assistant.set_title("New odML-Document wizard")
-        assistant.set_default_size(-1, 500)
+        assistant.set_default_size(800, 500)
         assistant.set_position(gtk.WIN_POS_CENTER_ALWAYS)
         assistant.connect("apply", self.apply)
         assistant.connect("close", self.cancel)
         assistant.connect("cancel", self.cancel)
 
-        IntroPage().deploy(assistant, "New Document Wizard")
-
         data_page = DataPage()
-        data_page.deploy(assistant, "General document information")
+        data_page.deploy(assistant, "Document information")
         self.data_page = data_page
 
         section_page = SectionPage()
         section_page.data = data_page
-        section_page.deploy(assistant, "Select which sections to import from the repository")
+        section_page.deploy(assistant, "Repository section import")
         self.section_page = section_page
 
         SummaryPage().deploy(assistant, "Complete")

--- a/odmlui/treemodel/PropertyModel.py
+++ b/odmlui/treemodel/PropertyModel.py
@@ -16,15 +16,15 @@ debug = lambda x: sys.stderr.write(x+"\n")
 debug = lambda x: 0
 
 
-ColMapper = ColumnMapper({"Name"        : (0, "name"),
-                         "Value"       : (1, "value"),
-                         "Definition"  : (2, "definition"),
-                         "Type"        : (3, "dtype"),
-                         "Unit"        : (4, "unit"),
-                         "Comment"     : (5, "comment"),
-                         "Endcoder"    : (6, "encoder"),
-                         "Filename"    : (7, "filename"),
-                         "Reference"   : (8, "reference")})
+ColMapper = ColumnMapper({"Name":        (0, "name"),
+                          "Value":       (1, "value"),
+                          "Unit":        (2, "unit"),
+                          "Type":        (3, "dtype"),
+                          "Definition":  (4, "definition"),
+                          "Comment":     (5, "comment"),
+                          "Endcoder":    (6, "encoder"),
+                          "Filename":    (7, "filename"),
+                          "Reference":   (8, "reference")})
 
 class PropertyModel(TreeModel):
     def __init__(self, section):

--- a/odmlui/treemodel/PropertyModel.py
+++ b/odmlui/treemodel/PropertyModel.py
@@ -19,12 +19,13 @@ debug = lambda x: 0
 ColMapper = ColumnMapper({"Name":        (0, "name"),
                           "Value":       (1, "value"),
                           "Unit":        (2, "unit"),
-                          "Type":        (3, "dtype"),
-                          "Definition":  (4, "definition"),
-                          "Comment":     (5, "comment"),
-                          "Endcoder":    (6, "encoder"),
-                          "Filename":    (7, "filename"),
-                          "Reference":   (8, "reference")})
+                          "Uncertainty": (3, "uncertainty"),
+                          "Type":        (4, "dtype"),
+                          "Definition":  (5, "definition"),
+                          "Comment":     (6, "comment"),
+                          "Endcoder":    (7, "encoder"),
+                          "Filename":    (8, "filename"),
+                          "Reference":   (9, "reference")})
 
 class PropertyModel(TreeModel):
     def __init__(self, section):

--- a/setup.py
+++ b/setup.py
@@ -39,9 +39,6 @@ except (ImportError, ValueError) as err:
 with open(readme) as f:
     description_text = f.read()
 
-with open("LICENSE") as f:
-    license_text = f.read()
-
 packages = [
     'odmlui',
     'odmlui.dnd',
@@ -72,6 +69,6 @@ setup(name='odML-UI',
       data_files=data_files,
       long_description=description_text,
       classifiers=CLASSIFIERS,
-      license=license_text,
+      license="BSD",
       test_suite='test'
       )


### PR DESCRIPTION
This PR
- removes the license text from setup.py. The license text interfered with the PyPI process in a way, that the description was not displayed on PyPI. With this setup it works fine.
- reduces the osx builds to one until further notice.
- removes the intro page from the wizard.
- adds uncertainty to the PropertyView and reorders PropertyView attritbutes to address #89.
- adjusts the height of the attribute window to always display all attributes.
- depending on the screen size uses a starting window size of 800x600 or 1024x768.

Once this PR has been merged and the package tested via testpypi.python.org, we can do the v1.3.0 release on PyPI proper.