### PR TITLE
[1.4] Fixes and updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,16 +45,30 @@ matrix:
     - os: osx
       language: generic
       env:
-        - OSXENV=2.7
-        - CONDA=Y
-        - CONDAPY=2.7
-
-    - os: osx
-      language: generic
-      env:
         - OSXENV=3.5
         - CONDA=Y
         - CONDAPY=3.5
+
+#    Keep only one osx branch active for now
+#    since currently osx builds on travis
+#    are frequently stalled or indefinitely delayed.
+#    - os: osx
+#      language: generic
+#      env:
+#        - OSXENV=2.7
+#        - CONDA=Y
+#        - CONDAPY=2.7
+#    - os: osx
+#      language: generic
+#      env:
+#        - OSXENV=2.7
+#        - CONDA=N
+#    - os: osx
+#      language: generic
+#      env:
+#        - OSXENV=3.5
+#        - CONDA=N
+
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then bash resources/install_osx_virtualenv.sh; fi

--- a/odmlui/AttributeView.py
+++ b/odmlui/AttributeView.py
@@ -1,14 +1,18 @@
+import cgi
 import pygtkcompat
 pygtkcompat.enable()
 pygtkcompat.enable_gtk(version='3.0')
 
 import gtk
-import cgi
 from odml import format as ofmt
+
 from . import commands
 from .TreeView import TreeView
+
 COL_KEY = 0
 COL_VALUE = 1
+
+
 class AttributeView(TreeView):
     """
     A key-value ListStore based TreeView
@@ -46,7 +50,7 @@ class AttributeView(TreeView):
         obj.add_change_handler(self.on_object_change)
 
         self._model = obj
-        self._fmt   = obj._format
+        self._fmt = obj._format
         self.fill()
 
     def get_model(self):
@@ -71,12 +75,12 @@ class AttributeView(TreeView):
 
     def on_edited(self, widget, row, new_value, col):
         store = self._store
-        iter = store.get_iter(row)
-        k = store.get_value(iter, COL_KEY)
+        store_iter = store.get_iter(row)
+        k = store.get_value(store_iter, COL_KEY)
         cmd = commands.ChangeValue(
-            object    = self._model,
-            attr      = self._fmt.map(k),
-            new_value = new_value)
+            object=self._model,
+            attr=self._fmt.map(k),
+            new_value=new_value)
 
         self.execute(cmd)
 

--- a/odmlui/AttributeView.py
+++ b/odmlui/AttributeView.py
@@ -1,6 +1,5 @@
-from gi import pygtkcompat
-
-pygtkcompat.enable() 
+import pygtkcompat
+pygtkcompat.enable()
 pygtkcompat.enable_gtk(version='3.0')
 
 import gtk

--- a/odmlui/AttributeView.py
+++ b/odmlui/AttributeView.py
@@ -4,7 +4,7 @@ pygtkcompat.enable_gtk(version='3.0')
 
 import gtk
 import cgi
-import odml.format as format
+from odml import format as ofmt
 from . import commands
 from .TreeView import TreeView
 COL_KEY = 0
@@ -23,6 +23,10 @@ class AttributeView(TreeView):
         self._model = None
         if obj is not None:
             self.set_model(obj)
+
+        # List of property attributes that is displayed in the property window
+        # and is not displayed again in the attribute view.
+        self._property_exclude = ["unit", "type", "uncertainty", "definition"]
 
         super(AttributeView, self).__init__(self._store)
 
@@ -56,6 +60,13 @@ class AttributeView(TreeView):
             if not isinstance(v, list):
                 if v is not None:
                     v = cgi.escape(v)
+
+                # Exclude property attributes that are displayed in the
+                # PropertyView window.
+                if isinstance(self._fmt, type(ofmt.Property)) and \
+                        k in self._property_exclude:
+                    continue
+
                 self._store.append([k, v])
 
     def on_edited(self, widget, row, new_value, col):

--- a/odmlui/ChooserDialog.py
+++ b/odmlui/ChooserDialog.py
@@ -1,5 +1,4 @@
-from gi import pygtkcompat
-
+import pygtkcompat
 pygtkcompat.enable()
 pygtkcompat.enable_gtk(version='3.0')
 

--- a/odmlui/ChooserDialog.py
+++ b/odmlui/ChooserDialog.py
@@ -5,15 +5,16 @@ pygtkcompat.enable_gtk(version='3.0')
 
 import gtk
 
+
 class ChooserDialog(gtk.FileChooserDialog):
     def __init__(self, title, save):
         default_button = gtk.STOCK_SAVE if save else gtk.STOCK_OPEN
         default_action = gtk.FILE_CHOOSER_ACTION_SAVE if save else gtk.FILE_CHOOSER_ACTION_OPEN
         super(ChooserDialog, self).__init__(
                 title=title,
-                buttons=(default_button, gtk.RESPONSE_OK,
-                         gtk.STOCK_CANCEL, gtk.RESPONSE_CANCEL),
                 action=default_action)
+        self.add_button(default_button, gtk.RESPONSE_OK)
+        self.add_button(gtk.STOCK_CANCEL, gtk.RESPONSE_CANCEL)
 
         self.save = save
         self.connect('response', self.response)
@@ -48,9 +49,9 @@ class odMLChooserDialog(ChooserDialog):
 
     @staticmethod
     def _setup_file_filter(filter):
-        '''
+        """
              Used for setting up recent filters for recently used files.
-        '''
+        """
         filter.set_name("odML Documents (*.xml, *.yaml, *.json, *.odml)")
 
         filter.add_mime_type("application/xml")
@@ -90,6 +91,6 @@ class odMLChooserDialog(ChooserDialog):
 
         if not self.save:
             all_files = gtk.FileFilter()
-            all_files.set_name ("All Files")
+            all_files.set_name("All Files")
             all_files.add_pattern("*")
-            self.add_filter (all_files)
+            self.add_filter(all_files)

--- a/odmlui/DragProvider.py
+++ b/odmlui/DragProvider.py
@@ -1,5 +1,4 @@
-from gi import pygtkcompat
-
+import pygtkcompat
 pygtkcompat.enable()
 pygtkcompat.enable_gtk(version='3.0')
 

--- a/odmlui/Editor.py
+++ b/odmlui/Editor.py
@@ -2,8 +2,7 @@ import os
 import platform
 import sys
 
-from gi import pygtkcompat
-
+import pygtkcompat
 pygtkcompat.enable()
 pygtkcompat.enable_gtk(version='3.0')
 

--- a/odmlui/Editor.py
+++ b/odmlui/Editor.py
@@ -309,7 +309,7 @@ class EditorWindow(gtk.Window):
         vpaned = gtk.VPaned()
         vpaned.show()
         # Adjust Attribute view position to default window size
-        vpaned.set_position(self.get_default_size().height - 340)
+        vpaned.set_position(self.get_default_size().height - 300)
         vpaned.pack1(hpaned, resize=True, shrink=False)
         vpaned.pack2(frame, resize=False, shrink=True)
 

--- a/odmlui/Editor.py
+++ b/odmlui/Editor.py
@@ -194,6 +194,13 @@ class EditorWindow(gtk.Window):
         self.set_title("odML Editor")
         self.set_default_size(800, 600)
 
+        # Check available screen size and adjust default app size to 1024x768 if possible.
+        screen = self.get_screen()
+        currmon = screen.get_monitor_at_window(screen.get_active_window())
+        mondims = screen.get_monitor_geometry(currmon)
+        if mondims.width >= 1024 and mondims.height >= 768:
+            self.set_default_size(1024, 768)
+
         icons = load_icon_pixbufs("odml-logo")
         self.set_icon_list(icons)
 

--- a/odmlui/Editor.py
+++ b/odmlui/Editor.py
@@ -216,7 +216,7 @@ class EditorWindow(gtk.Window):
         bar = merge.get_widget("/MenuBar")
         bar.show()
 
-        table = gtk.Table(2, 6, False)
+        table = gtk.Table(n_rows=2, n_columns=6, homogeneous=False)
         self.add(table)
 
         table.attach(bar,
@@ -393,10 +393,10 @@ class EditorWindow(gtk.Window):
                     (v.name, v.stock_id, v.label, v.accelerator,
                      v.tooltip, getattr(self, k)))
 
-        recent_action = gtk.RecentAction("OpenRecent",
-                                         "Open Recent",
-                                         "Open Recent Files",
-                                         gtk.STOCK_OPEN)
+        recent_action = gtk.RecentAction(name="OpenRecent",
+                                         label="Open Recent",
+                                         tooltip="Open Recent Files",
+                                         stock_id=gtk.STOCK_OPEN)
         recent_action.connect("item-activated", self.open_recent)
 
         recent_filter = gtk.RecentFilter()
@@ -406,7 +406,7 @@ class EditorWindow(gtk.Window):
         recent_action.add_filter(recent_filter)
         recent_action.set_show_not_found(False)
 
-        action_group = gtk.ActionGroup("EditorActions")
+        action_group = gtk.ActionGroup(name="EditorActions")
         self.editor_actions = action_group
         action_group.add_actions(entries)
         action_group.add_action(recent_action)
@@ -659,8 +659,8 @@ class EditorWindow(gtk.Window):
 
     def mk_tab_label(self, tab):
         # hbox will be used to store a label and button, as notebook tab title
-        hbox = gtk.HBox(False, 0)
-        label = gtk.Label(tab.get_name())
+        hbox = gtk.HBox(homogeneous=False, spacing=0)
+        label = gtk.Label(label=tab.get_name())
         tab.label = label
         hbox.pack_start(label)
 

--- a/odmlui/Editor.py
+++ b/odmlui/Editor.py
@@ -308,7 +308,8 @@ class EditorWindow(gtk.Window):
 
         vpaned = gtk.VPaned()
         vpaned.show()
-        vpaned.set_position(350)
+        # Adjust Attribute view position to default window size
+        vpaned.set_position(self.get_default_size().height - 340)
         vpaned.pack1(hpaned, resize=True, shrink=False)
         vpaned.pack2(frame, resize=False, shrink=True)
 

--- a/odmlui/Editor.py
+++ b/odmlui/Editor.py
@@ -1097,7 +1097,7 @@ def register_stock_icons():
 
             img_path = os.path.join(img_dir, name)
             icon = load_pixbuf(img_path)
-            icon_set = gtk.IconSet(icon)
+            icon_set = gtk.IconSet.new_from_pixbuf(icon)
 
             for icon in load_icon_pixbufs(icon_name):
                 src = gtk.IconSource()

--- a/odmlui/EditorTab.py
+++ b/odmlui/EditorTab.py
@@ -1,5 +1,4 @@
-from gi import pygtkcompat
-
+import pygtkcompat
 pygtkcompat.enable()
 pygtkcompat.enable_gtk(version='3.0')
 

--- a/odmlui/EditorTab.py
+++ b/odmlui/EditorTab.py
@@ -93,10 +93,14 @@ class EditorTab(object):
         if not self.is_modified:
             return True
 
-        dialog = gtk.MessageDialog(self.window, gtk.DIALOG_MODAL,
-                                   gtk.MESSAGE_INFO, gtk.BUTTONS_YES_NO,
-                                   "%s has been modified. Do you want to save your changes?" %
-                                   (self.file_uri if self.file_uri is not None else "The document"))
+        msg = "%s has been modified. Do you want to save your changes?" % (
+            self.file_uri if self.file_uri is not None else "The document")
+
+        dialog = gtk.MessageDialog(transient_for=self.window,
+                                   modal=True,
+                                   message_type=gtk.MESSAGE_INFO,
+                                   buttons=gtk.BUTTONS_YES_NO,
+                                   text=msg)
 
         dialog.add_button(gtk.STOCK_CANCEL, gtk.RESPONSE_CANCEL)
         dialog.set_title("Save changes?")

--- a/odmlui/InfoBar.py
+++ b/odmlui/InfoBar.py
@@ -3,8 +3,9 @@ from gi import pygtkcompat
 pygtkcompat.enable() 
 pygtkcompat.enable_gtk(version='3.0')
 
-import gtk
+import glib
 import gobject
+import gtk
 
 
 class EditorInfoBar(gtk.InfoBar):
@@ -12,7 +13,7 @@ class EditorInfoBar(gtk.InfoBar):
         gtk.InfoBar.__init__(self, *args, **kargs)
         self._msg_label = gtk.Label(label="")
         self._msg_label.show()
-        self.get_content_area().pack_start (self._msg_label, True, True, 0)
+        self.get_content_area().pack_start(self._msg_label, True, True, 0)
         self.add_button(gtk.STOCK_OK, gtk.RESPONSE_OK)
 
         self.connect("response", self._on_response)
@@ -37,7 +38,7 @@ class EditorInfoBar(gtk.InfoBar):
         self.show()
 
     def add_timer(self, seconds=3):
-        self._timerid = gobject.timeout_add_seconds(seconds, self.on_timer)
+        self._timerid = glib.timeout_add_seconds(seconds, self.on_timer)
 
     def on_timer(self):
         self.hide()

--- a/odmlui/InfoBar.py
+++ b/odmlui/InfoBar.py
@@ -1,6 +1,5 @@
-from gi import pygtkcompat
-
-pygtkcompat.enable() 
+import pygtkcompat
+pygtkcompat.enable()
 pygtkcompat.enable_gtk(version='3.0')
 
 import glib

--- a/odmlui/InfoBar.py
+++ b/odmlui/InfoBar.py
@@ -6,10 +6,11 @@ pygtkcompat.enable_gtk(version='3.0')
 import gtk
 import gobject
 
+
 class EditorInfoBar(gtk.InfoBar):
     def __init__(self, *args, **kargs):
         gtk.InfoBar.__init__(self, *args, **kargs)
-        self._msg_label = gtk.Label("")
+        self._msg_label = gtk.Label(label="")
         self._msg_label.show()
         self.get_content_area().pack_start (self._msg_label, True, True, 0)
         self.add_button(gtk.STOCK_OK, gtk.RESPONSE_OK)

--- a/odmlui/InfoBar.py
+++ b/odmlui/InfoBar.py
@@ -21,7 +21,7 @@ class EditorInfoBar(gtk.InfoBar):
 
     def _on_response(self, obj, response_id):
         if self._timerid > 0:
-            gobject.source_remove(self._timerid)
+            glib.source_remove(self._timerid)
             self._timerid = 0
         self.hide()
 

--- a/odmlui/MessageDialog.py
+++ b/odmlui/MessageDialog.py
@@ -1,5 +1,4 @@
-from gi import pygtkcompat
-
+import pygtkcompat
 pygtkcompat.enable()
 pygtkcompat.enable_gtk(version='3.0')
 

--- a/odmlui/NavigationBar.py
+++ b/odmlui/NavigationBar.py
@@ -1,6 +1,5 @@
-from gi import pygtkcompat
-
-pygtkcompat.enable() 
+import pygtkcompat
+pygtkcompat.enable()
 pygtkcompat.enable_gtk(version='3.0')
 
 import gtk

--- a/odmlui/PropertyView.py
+++ b/odmlui/PropertyView.py
@@ -1,5 +1,4 @@
-from gi import pygtkcompat
-
+import pygtkcompat
 pygtkcompat.enable()
 pygtkcompat.enable_gtk(version='3.0')
 

--- a/odmlui/ScrolledWindow.py
+++ b/odmlui/ScrolledWindow.py
@@ -1,9 +1,9 @@
-from gi import pygtkcompat
-
-pygtkcompat.enable() 
+import pygtkcompat
+pygtkcompat.enable()
 pygtkcompat.enable_gtk(version='3.0')
 
 import gtk
+
 
 class ScrolledWindow(gtk.ScrolledWindow):
     def __init__(self, widget):

--- a/odmlui/TextEditor.py
+++ b/odmlui/TextEditor.py
@@ -1,6 +1,5 @@
-from gi import pygtkcompat
-
-pygtkcompat.enable() 
+import pygtkcompat
+pygtkcompat.enable()
 pygtkcompat.enable_gtk(version='3.0')
 
 import gtk

--- a/odmlui/TreeView.py
+++ b/odmlui/TreeView.py
@@ -1,5 +1,4 @@
-from gi import pygtkcompat
-
+import pygtkcompat
 pygtkcompat.enable()
 pygtkcompat.enable_gtk(version='3.0')
 

--- a/odmlui/TreeView.py
+++ b/odmlui/TreeView.py
@@ -15,7 +15,7 @@ class TreeView(object):
     popup = None
 
     def __init__(self, store=None):
-        tv = gtk.TreeView(store)
+        tv = gtk.TreeView(model=store)
         tv.set_headers_visible(False)
 
         if self.on_selection_change is not None:

--- a/odmlui/ValidationWindow.py
+++ b/odmlui/ValidationWindow.py
@@ -1,5 +1,4 @@
-from gi import pygtkcompat
-
+import pygtkcompat
 pygtkcompat.enable()
 pygtkcompat.enable_gtk(version='3.0')
 

--- a/odmlui/Wizard.py
+++ b/odmlui/Wizard.py
@@ -13,7 +13,6 @@ from .SectionView import SectionView
 from .ScrolledWindow import ScrolledWindow
 
 
-
 class Table(object):
     def __init__(self, cols):
         self.table = gtk.Table(rows=1, columns=cols)
@@ -62,17 +61,6 @@ class Page(gtk.VBox):
         called to finish processing the page and allow it to collect all entered data
         """
         pass
-
-
-class IntroPage(Page):
-    type = gtk.ASSISTANT_PAGE_INTRO
-    complete = True
-
-    def init(self):
-        label = gtk.Label("Welcome! This assistant will guide you trough the first " +
-                          "steps of creating a new odML-Document")
-        label.set_line_wrap(True)
-        self.pack_start(label, True, True, 0)
 
 
 def get_username():
@@ -207,21 +195,19 @@ class DocumentWizard:
         assistant = gtk.Assistant()
 
         assistant.set_title("New odML-Document wizard")
-        assistant.set_default_size(-1, 500)
+        assistant.set_default_size(800, 500)
         assistant.set_position(gtk.WIN_POS_CENTER_ALWAYS)
         assistant.connect("apply", self.apply)
         assistant.connect("close", self.cancel)
         assistant.connect("cancel", self.cancel)
 
-        IntroPage().deploy(assistant, "New Document Wizard")
-
         data_page = DataPage()
-        data_page.deploy(assistant, "General document information")
+        data_page.deploy(assistant, "Document information")
         self.data_page = data_page
 
         section_page = SectionPage()
         section_page.data = data_page
-        section_page.deploy(assistant, "Select which sections to import from the repository")
+        section_page.deploy(assistant, "Repository section import")
         self.section_page = section_page
 
         SummaryPage().deploy(assistant, "Complete")

--- a/odmlui/Wizard.py
+++ b/odmlui/Wizard.py
@@ -15,7 +15,7 @@ from .ScrolledWindow import ScrolledWindow
 
 class Table(object):
     def __init__(self, cols):
-        self.table = gtk.Table(rows=1, columns=cols)
+        self.table = gtk.Table(n_rows=1, n_columns=cols)
         self.cols = cols
         self.rows = 0
 
@@ -95,7 +95,7 @@ class DataPage(Page):
 
         # add a label and an entry box for each field
         for k, v in fields.items():
-            label = gtk.Label("%s: " % k)
+            label = gtk.Label(label="%s: " % k)
             label.set_alignment(1, 0.5)
             entry = gtk.Entry()
             entry.set_text(v)
@@ -172,7 +172,8 @@ class SectionPage(Page):
         self.pack_start(ScrolledWindow(self.view._treeview), True, True, 0)
 
     def prepare(self, assistant, prev_page):
-        if "repository" in prev_page.data.keys() and len(prev_page.data["repository"].strip()) > 0:
+        if "repository" in prev_page.data.keys() and \
+                        len(prev_page.data["repository"].strip()) > 0:
             self.term = terminology.terminologies.load(prev_page.data['repository'])
             self.view.set_model(SectionModel(self.term))
 
@@ -187,7 +188,8 @@ class SummaryPage(Page):
     type = gtk.ASSISTANT_PAGE_CONFIRM
 
     def init(self):
-        self.add(gtk.Label("All information has been gathered. Ready to create document."))
+        self.add(gtk.Label(label="All information has been gathered. "
+                                 "Ready to create document."))
 
 
 class DocumentWizard:

--- a/odmlui/Wizard.py
+++ b/odmlui/Wizard.py
@@ -102,7 +102,7 @@ class DataPage(Page):
         fields['Author'] = get_username()
         fields['Date'] = get_date()
         fields['Version'] = '1.0'
-        fields['Repository'] = 'http://portal.g-node.org/odml/terminologies/v1.0/terminologies.xml'
+        fields['Repository'] = terminology.REPOSITORY
         self.fields = fields
 
         # add a label and an entry box for each field

--- a/odmlui/Wizard.py
+++ b/odmlui/Wizard.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 from collections import OrderedDict
-from gi import pygtkcompat
-
+import pygtkcompat
 pygtkcompat.enable()
 pygtkcompat.enable_gtk(version='3.0')
 

--- a/odmlui/__main__.py
+++ b/odmlui/__main__.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
-from gi import pygtkcompat
-
+import pygtkcompat
 pygtkcompat.enable()
 pygtkcompat.enable_gtk(version='3.0')
 

--- a/odmlui/dnd/drag.py
+++ b/odmlui/dnd/drag.py
@@ -1,5 +1,4 @@
-from gi import pygtkcompat
-
+import pygtkcompat
 pygtkcompat.enable()
 pygtkcompat.enable_gtk(version='3.0')
 

--- a/odmlui/dnd/drop.py
+++ b/odmlui/dnd/drop.py
@@ -1,5 +1,4 @@
-from gi import pygtkcompat
-
+import pygtkcompat
 pygtkcompat.enable()
 pygtkcompat.enable_gtk(version='3.0')
 

--- a/odmlui/dnd/odmldrop.py
+++ b/odmlui/dnd/odmldrop.py
@@ -1,5 +1,4 @@
-from gi import pygtkcompat
-
+import pygtkcompat
 pygtkcompat.enable()
 pygtkcompat.enable_gtk(version='3.0')
 

--- a/odmlui/dnd/text.py
+++ b/odmlui/dnd/text.py
@@ -1,5 +1,4 @@
-from gi import pygtkcompat
-
+import pygtkcompat
 pygtkcompat.enable()
 pygtkcompat.enable_gtk(version='3.0')
 

--- a/odmlui/dnd/tree.py
+++ b/odmlui/dnd/tree.py
@@ -1,5 +1,4 @@
-from gi import pygtkcompat
-
+import pygtkcompat
 pygtkcompat.enable()
 pygtkcompat.enable_gtk(version='3.0')
 

--- a/odmlui/info.py
+++ b/odmlui/info.py
@@ -1,4 +1,4 @@
-VERSION = '1.4.dev'
+VERSION = '1.4.0'
 STATUS = 'Release'
 RELEASE = '%s %s' % (VERSION, STATUS)
 AUTHOR = 'Shubham Dighe, Hagen Fritsch, Christian Kellner, Jan Grewe, Achilleas Koutsou, \

--- a/odmlui/treemodel/PropertyModel.py
+++ b/odmlui/treemodel/PropertyModel.py
@@ -2,14 +2,13 @@ import pygtkcompat
 pygtkcompat.enable()
 pygtkcompat.enable_gtk(version='3.0')
 
-import gtk, gobject
+import sys
+import odml
+import odml.property
 import odmlui
 
 from .TreeIters import PropIter, ValueIter, SectionPropertyIter
 from .TreeModel import TreeModel, ColumnMapper
-import sys
-import odml
-import odml.property
 from . import ValueModel
 debug = lambda x: sys.stderr.write(x+"\n")
 debug = lambda x: 0
@@ -23,6 +22,7 @@ ColMapper = ColumnMapper({"Name":        (0, "name"),
                           "Definition":  (5, "definition"),
                           })
 
+
 class PropertyModel(TreeModel):
     def __init__(self, section):
         super(PropertyModel, self).__init__(ColMapper)
@@ -30,14 +30,15 @@ class PropertyModel(TreeModel):
         self._section.add_change_handler(self.on_section_changed)
         self.offset = len(section.to_path())
 
-    def model_path_to_odml_path(self, path):
+    @staticmethod
+    def model_path_to_odml_path(path):
         # (n, ...) -> (1, ...)
         # this can only go wrong sometimes because properties
         # with only one value share a common path
-        return (1,) + tuple(path.get_indices()) # we consider properties only
+        return (1,) + tuple(path.get_indices())  # we consider properties only
 
     def odml_path_to_model_path(self, path):
-        if len(path) == 3: # 1, prop, val
+        if len(path) == 3:  # 1, prop, val
             # if only one child, return property row
             if len(self._section.from_path(path[:2])) == 1:
                 return path[1:2]
@@ -46,9 +47,10 @@ class PropertyModel(TreeModel):
     def on_get_iter(self, path):
         debug(":on_get_iter [%s] " % repr(path))
 
-        if len(self._section._props) == 0: return None
+        if len(self._section._props) == 0:
+            return None
 
-        path = self.model_path_to_odml_path(path) # we consider properties only
+        path = self.model_path_to_odml_path(path)  # we consider properties only
         node = self._section.from_path(path)
         return self._get_node_iter(node)
 
@@ -57,7 +59,8 @@ class PropertyModel(TreeModel):
         add some coloring to the value in certain cases
         """
         v = super(PropertyModel, self).on_get_value(tree_iter, column)
-        if v is None: return v
+        if v is None:
+            return v
 
         obj = tree_iter._obj
         if isinstance(tree_iter, ValueIter):
@@ -72,7 +75,7 @@ class PropertyModel(TreeModel):
 
     def on_iter_nth_child(self, tree_iter, n):
         debug(":on_iter_nth_child [%d]: %s " % (n, tree_iter))
-        if tree_iter == None:
+        if tree_iter is None:
             prop = self._section._props[n]
             return PropIter(prop)
         return super(PropertyModel, self).on_iter_nth_child(tree_iter, n)
@@ -92,7 +95,7 @@ class PropertyModel(TreeModel):
                 # the last child row is also not present anymore,
                 # the value is now displayed inline
                 path = self.get_node_path(parent)
-                self.row_deleted(path + (0,)) # first child
+                self.row_deleted(path + (0,))  # first child
                 self.row_has_child_toggled(path, self.get_iter(path))
 
     def post_insert(self, node):
@@ -112,29 +115,32 @@ class PropertyModel(TreeModel):
 
         # we are only interested in changes going up to the section level,
         # but not those dealing with subsections of ours
-        if not context.cur is self._section or \
+        if context.cur is not self._section or \
                 isinstance(context.val, odml.section.Section):
             return
 
         if context.action == "set" and context.post_change:
             path = self.get_node_path(context.obj)
-            if not path: return # probably the section changed
+            if not path:
+                return  # probably the section changed
             try:
-                iter = self.get_iter(path)
-                self.row_changed(path, iter)
-            except ValueError as e: # an invalid tree path, that should never have reached us
+                curriter = self.get_iter(path)
+                self.row_changed(path, curriter)
+            except ValueError as e:
+                # an invalid tree path, that should never have reached us
                 print(repr(e))
                 print(context.dump())
 
         # there was some reason we did this, however context.obj can
         # also be a property of the current section
-        #if not context.obj is self._section:
+        # if not context.obj is self._section:
         #    return
 
         if context.action == "remove":
             self.event_remove(context)
 
-        if (context.action == "append" or context.action == "insert") and context.post_change:
+        if (context.action == "append" or
+                context.action == "insert") and context.post_change:
             self.event_insert(context)
 
         if context.action == "reorder":
@@ -144,7 +150,7 @@ class PropertyModel(TreeModel):
         self._section.remove_change_handler(self.on_section_changed)
 
     def __repr__(self):
-        return "<PropertyModel of %s>" % (self.section)
+        return "<PropertyModel of %s>" % self.section
 
     @property
     def section(self):

--- a/odmlui/treemodel/PropertyModel.py
+++ b/odmlui/treemodel/PropertyModel.py
@@ -15,12 +15,13 @@ debug = lambda x: sys.stderr.write(x+"\n")
 debug = lambda x: 0
 
 
-ColMapper = ColumnMapper({"Name"        : (0, "name"),
-                         "Value"       : (1, "pseudo_values"),
-                         "Definition"  : (2, "definition"),
-                         "Type"        : (3, "dtype"),
-                         "Unit"        : (4, "unit"),
-                         })
+ColMapper = ColumnMapper({"Name":        (0, "name"),
+                          "Value":       (1, "pseudo_values"),
+                          "Type":        (2, "dtype"),
+                          "Unit":        (3, "unit"),
+                          "Uncertainty": (4, "uncertainty"),
+                          "Definition":  (5, "definition"),
+                          })
 
 class PropertyModel(TreeModel):
     def __init__(self, section):

--- a/odmlui/treemodel/PropertyModel.py
+++ b/odmlui/treemodel/PropertyModel.py
@@ -1,6 +1,5 @@
-from gi import pygtkcompat
-
-pygtkcompat.enable() 
+import pygtkcompat
+pygtkcompat.enable()
 pygtkcompat.enable_gtk(version='3.0')
 
 import gtk, gobject

--- a/odmlui/treemodel/PropertyModel.py
+++ b/odmlui/treemodel/PropertyModel.py
@@ -2,16 +2,12 @@ import pygtkcompat
 pygtkcompat.enable()
 pygtkcompat.enable_gtk(version='3.0')
 
-import sys
 import odml
 import odml.property
-import odmlui
 
 from .TreeIters import PropIter, ValueIter, SectionPropertyIter
 from .TreeModel import TreeModel, ColumnMapper
 from . import ValueModel
-debug = lambda x: sys.stderr.write(x+"\n")
-debug = lambda x: 0
 
 
 ColMapper = ColumnMapper({"Name":        (0, "name"),
@@ -45,8 +41,6 @@ class PropertyModel(TreeModel):
         return path[1:]
 
     def on_get_iter(self, path):
-        debug(":on_get_iter [%s] " % repr(path))
-
         if len(self._section._props) == 0:
             return None
 
@@ -74,7 +68,6 @@ class PropertyModel(TreeModel):
         return super(PropertyModel, self).on_iter_n_children(tree_iter)
 
     def on_iter_nth_child(self, tree_iter, n):
-        debug(":on_iter_nth_child [%d]: %s " % (n, tree_iter))
         if tree_iter is None:
             prop = self._section._props[n]
             return PropIter(prop)
@@ -110,9 +103,6 @@ class PropertyModel(TreeModel):
         this is called by the Eventable modified MixIns of Value/Property/Section
         and causes the GUI to refresh the corresponding cells
         """
-        if odmlui.DEBUG:
-            print("change event(property): ", context)
-
         # we are only interested in changes going up to the section level,
         # but not those dealing with subsections of ours
         if context.cur is not self._section or \

--- a/odmlui/treemodel/SectionModel.py
+++ b/odmlui/treemodel/SectionModel.py
@@ -1,6 +1,5 @@
-from gi import pygtkcompat
-
-pygtkcompat.enable() 
+import pygtkcompat
+pygtkcompat.enable()
 pygtkcompat.enable_gtk(version='3.0')
 
 import gtk, gobject

--- a/odmlui/treemodel/TreeModel.py
+++ b/odmlui/treemodel/TreeModel.py
@@ -1,5 +1,4 @@
-from gi import pygtkcompat
-
+import pygtkcompat
 pygtkcompat.enable()
 pygtkcompat.enable_gtk(version='3.0')
 

--- a/odmlui/treemodel/nodes.py
+++ b/odmlui/treemodel/nodes.py
@@ -1,21 +1,22 @@
 """
-provides node functionality for the eventable odml types
-Document, Section, Property and Value
+Provides node functionality for the eventable odml types
+Document, Section, Property and Value.
 
-additionally implements change notifications up to the corresponding section
+Additionally implements change notifications up to the corresponding section.
 """
 import odml.property
 from . import event
 
+
 def identity_index(obj, val):
     """
-    same as obj.index(val) but will only return a position
-    if the object val is found in the list
+    Same as obj.index(val) but will only return a position
+    if the object val is found in the list.
 
     i.e.
     >>> identity_index(["1"], "1")
-    will raise an ValueError because the two strings
-    are different objects with the same content
+    will raise a ValueError because the two strings
+    are different objects with the same content.
 
     >>> a = "1"
     >>> identity_index([a], a)
@@ -29,9 +30,11 @@ def identity_index(obj, val):
     0
     """
     for i, v in enumerate(obj):
-        if v is val: return i
+        if v is val:
+            return i
 
     raise ValueError("%s does not contain the item %s" % (repr(obj), repr(val)))
+
 
 class RootNode(object):
     @property
@@ -49,7 +52,8 @@ class RootNode(object):
 
     def path_to(self, child):
         """return the path from this node to its direct child *child*"""
-        return (identity_index(self._sections, child),)
+        return identity_index(self._sections, child),
+
 
 class ParentedNode(RootNode):
     def to_path(self, parent=None):
@@ -83,6 +87,7 @@ class ParentedNode(RootNode):
     def position(self):
         return self.parent.path_to(self)[-1]
 
+
 class SectionNode(ParentedNode):
     """
     SectionNodes are special as they wrap two types of sub-nodes:
@@ -93,7 +98,7 @@ class SectionNode(ParentedNode):
     def from_path(self, path):
         assert len(path) > 1
 
-        if path[0] == 0: # sections
+        if path[0] == 0:  # sections
             return super(SectionNode, self).from_path(path[1:])
 
         # else: properties
@@ -105,8 +110,8 @@ class SectionNode(ParentedNode):
 
     def path_to(self, child):
         if isinstance(child, odml.property.Property):
-            return (1, identity_index(self._props, child))
-        return (0, identity_index(self._sections, child))
+            return 1, identity_index(self._props, child)
+        return 0, identity_index(self._sections, child)
 
 
 class PropertyNode(ParentedNode):
@@ -118,7 +123,8 @@ class PropertyNode(ParentedNode):
         return self.parent._props[self.position + 1]
 
     def path_to(self, child):
-        return (identity_index(self.pseudo_values, child),)
+        return identity_index(self.pseudo_values, child),
+
 
 class ValueNode(ParentedNode):
     def path_from(self, path):
@@ -127,14 +133,28 @@ class ValueNode(ParentedNode):
     def path_to(self, child):
         raise TypeError("Value objects have no children")
 
-#TODO? provide this externally?
+
+# TODO? provide this externally?
 name = "nodes"
 provides = event.provides + ["nodes"]
-class Document(event.Document, RootNode): pass
-# class Value(event.Value, ValueNode): pass
-class Value(ValueNode): pass
-class Property(event.Property, PropertyNode): pass
-class Section(event.Section, SectionNode): pass
 
-import sys, odml
+
+class Document(event.Document, RootNode):
+    pass
+
+
+class Value(ValueNode):
+    pass
+
+
+class Property(event.Property, PropertyNode):
+    pass
+
+
+class Section(event.Section, SectionNode):
+    pass
+
+
+import sys
+import odml
 odml.addImplementation(sys.modules[__name__])

--- a/odmlui/treemodel/nodes.py
+++ b/odmlui/treemodel/nodes.py
@@ -31,7 +31,6 @@ def identity_index(obj, val):
     for i, v in enumerate(obj):
         if v is val: return i
 
-    import pdb; pdb.set_trace()
     raise ValueError("%s does not contain the item %s" % (repr(obj), repr(val)))
 
 class RootNode(object):

--- a/setup.py
+++ b/setup.py
@@ -39,9 +39,6 @@ except (ImportError, ValueError) as err:
 with open(readme) as f:
     description_text = f.read()
 
-with open("LICENSE") as f:
-    license_text = f.read()
-
 packages = [
     'odmlui',
     'odmlui.dnd',
@@ -72,6 +69,6 @@ setup(name='odML-UI',
       data_files=data_files,
       long_description=description_text,
       classifiers=CLASSIFIERS,
-      license=license_text,
+      license="BSD",
       test_suite='test'
       )


### PR DESCRIPTION
This PR introduces the following fixes and updates:
- removes a hardcoded breakpoint to avoid application freeze; closes #108.
- bumps the version to 1.4.0.
- uses the default odml-terminologies now defined in [python-odml](https://github.com/G-Node/python-odml/pull/209).
- removes the wizard intro page; closes #103.
- refactors code to avoid GTK deprecation warnings; closes #98.
- depending on the screen size uses a starting window size of 800x600 or 1024x768.
- adjusts the height of the attribute window to always display all attributes.
- Adds "uncertainty" to the PropertyView window and reorders the available columns;  closes #89.
- removes the license text from setup.py. The license text interfered with the PyPI process in a way, that the description was not displayed on PyPI. With this setup it works fine.
- osx builds on travis currently take quite some time until they start. Therefore the osx builds are reduced to one until further notice.