### PR TITLE
Value handling and install fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.pyc
 *.pyo
 *.egg
+*.eggs
 *.egg-info
 dist
 build

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include LICENSE
 include README.rst
 include odml.desktop
+include odmlui/info.json

--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,7 @@ Anaconda environments require only the following packages before installing the 
 MacOS using homebrew:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 For Python 2 (Python 3)
+
 * :code:`brew install gtk+ (gtk+3)`
 * :code:`brew install pygobject (pygobject3)`
 * :code:`brew install gnome-icon-theme`

--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,8 @@ Anaconda environments require only the following packages before installing the 
     $ conda install -c conda-forge gdk-pixbuf
     $ conda install -c pkgw-forge adwaita-icon-theme
 
+These dependencies currently only work on Linux, MacOS is not supported!
+
 MacOS using homebrew:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 For Python 2 (Python 3)

--- a/odmlui/Editor.py
+++ b/odmlui/Editor.py
@@ -196,7 +196,13 @@ class EditorWindow(gtk.Window):
 
         # Check available screen size and adjust default app size to 1024x768 if possible.
         screen = self.get_screen()
-        currmon = screen.get_monitor_at_window(screen.get_active_window())
+        # Use first available monitor as default.
+        currmon = 0
+        actwin = screen.get_active_window()
+        # Set current monitor only, when active window returns not None.
+        if actwin:
+            currmon = screen.get_monitor_at_window(actwin)
+
         mondims = screen.get_monitor_geometry(currmon)
         if mondims.width >= 1024 and mondims.height >= 768:
             self.set_default_size(1024, 768)

--- a/odmlui/EditorTab.py
+++ b/odmlui/EditorTab.py
@@ -7,7 +7,7 @@ import os.path
 
 import odml
 import odml.validation
-from odml.tools.odmlparser import ODMLReader, ODMLWriter, allowed_parsers
+from odml.tools.odmlparser import ODMLReader, ODMLWriter
 
 from .CommandManager import CommandManager
 from .Helpers import uri_to_path, get_parser_for_uri, get_extension, \

--- a/odmlui/Helpers.py
+++ b/odmlui/Helpers.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 
 from odml import fileio
-from odml.tools.odmlparser import allowed_parsers
+from odml.tools.parser_utils import SUPPORTED_PARSERS
 from .treemodel import ValueModel
 
 try:  # Python 3
@@ -49,7 +49,7 @@ def get_parser_for_uri(uri):
     path = uri_to_path(uri)
     parser = get_extension(path)
 
-    if parser not in allowed_parsers:
+    if parser not in SUPPORTED_PARSERS:
         parser = 'XML'
 
     return parser
@@ -63,7 +63,7 @@ def get_parser_for_file_type(file_type):
     Returns either the identified parser or XML as the fallback parser.
     """
     parser = file_type.upper()
-    if file_type not in allowed_parsers:
+    if file_type not in SUPPORTED_PARSERS:
         parser = 'XML'
     return parser
 

--- a/odmlui/ValidationWindow.py
+++ b/odmlui/ValidationWindow.py
@@ -93,17 +93,31 @@ class ValidationWindow(gtk.Window):
 
 if __name__ == "__main__":
     from odml.validation import Validation
-    from odml.tools.jsonparser import JSONReader
+    from odml.tools.odmlparser import ODMLReader
 
-    class Tab:  # a small stupid mock object
-        document = JSONReader().fromString("""
-    {"_type": "Document", "section": [
-        {"_type": "Section", "name": "sec1", "property": [
-            {"_type": "Property", "name": "prop1", "value": [{"_type": "Value", "value": "1"}]},
-            {"_type": "Property", "name": "prop1", "value": [{"_type": "Value", "value": "1"}]}
-        ]}
-    ]}
-    """)
+    class Tab:  # a small mock object
+        document = ODMLReader("JSON").from_string("""
+{
+    "odml-version": "1.1",
+    "Document": {
+        "sections": [{
+                "sections": [],
+                "properties": [
+                    {
+                        "dtype": "string",
+                        "name": "Unnamed Property",
+                        "value": [""]
+                    },{
+                        "dtype": "string",
+                        "name": "Unnamed Property 1",
+                        "value": [""]
+                    }
+                ],
+                "name": "Unnamed Section"
+        }]
+    }
+}
+""")
 
         def get_name(self):
             return "animal_keeping.odml"

--- a/odmlui/info.json
+++ b/odmlui/info.json
@@ -1,0 +1,17 @@
+{
+  "VERSION": "1.4.0",
+  "AUTHOR": "Shubham Dighe, Hagen Fritsch, Christian Kellner, Jan Grewe, Achilleas Koutsou, Michael Sonntag",
+  "COPYRIGHT": "(c) 2011-2017, German Neuroinformatics Node",
+  "CONTACT": "dev@g-node.org",
+  "HOMEPAGE": "https://github.com/G-Node/odml-ui",
+  "CLASSIFIERS": [
+    "Programming Language :: Python :: 2",
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: BSD License",
+    "Development Status :: 4 - Beta",
+    "Topic :: Scientific/Engineering",
+    "Intended Audience :: Science/Research",
+    "Intended Audience :: End Users/Desktop"
+  ],
+  "ODMLTABLES_VERSION": "1.2.0"
+}

--- a/odmlui/info.py
+++ b/odmlui/info.py
@@ -1,18 +1,15 @@
-VERSION = '1.4.0'
-STATUS = 'Release'
-RELEASE = '%s %s' % (VERSION, STATUS)
-AUTHOR = 'Shubham Dighe, Hagen Fritsch, Christian Kellner, Jan Grewe, Achilleas Koutsou, \
-Michael Sonntag'
-COPYRIGHT = '(c) 2011-2017, German Neuroinformatics Node'
-CONTACT = 'dev@g-node.org'
-HOMEPAGE = 'https://github.com/G-Node/odml-ui'
-CLASSIFIERS = [
-    'Programming Language :: Python :: 2',
-    'Programming Language :: Python :: 3',
-    'License :: OSI Approved :: BSD License',
-    'Development Status :: 4 - Beta',
-    'Topic :: Scientific/Engineering',
-    'Intended Audience :: Science/Research',
-    'Intended Audience :: End Users/Desktop'
-]
-ODMLTABLES_VERSION = '1.2.0'
+import os
+import json
+
+here = os.path.dirname(__file__)
+
+with open(os.path.join(here, "info.json")) as infofile:
+    infodict = json.load(infofile)
+
+VERSION = infodict["VERSION"]
+AUTHOR = infodict["AUTHOR"]
+COPYRIGHT = infodict["COPYRIGHT"]
+CONTACT = infodict["CONTACT"]
+HOMEPAGE = infodict["HOMEPAGE"]
+CLASSIFIERS = infodict["CLASSIFIERS"]
+ODMLTABLES_VERSION = infodict["ODMLTABLES_VERSION"]

--- a/odmlui/treemodel/ValueModel.py
+++ b/odmlui/treemodel/ValueModel.py
@@ -44,7 +44,12 @@ class Value(base.baseobject, base._baseobj, ValueNode, event.ModificationNotifie
             index = len(self._property.value)
             dtype = self.parent.dtype
             default_value = dtypes.default_values(dtype)
-            self.parent.value.append(default_value)
+            # property.value returns a copy: we therefore need an in between step
+            # to append a new value and reassign the modified value to the parent
+            # property.value.
+            val_cp = self.parent.value
+            val_cp.append(default_value)
+            self.parent.value = val_cp
 
         assert(isinstance(index, int))
         self._index = index

--- a/odmlui/treemodel/event.py
+++ b/odmlui/treemodel/event.py
@@ -223,7 +223,29 @@ class ModificationNotifier(ChangeHandlable):
         func = lambda: super(ModificationNotifier, self)._reorder(childlist, new_index)
         return self.__fireChange("reorder", (childlist, new_index), func)
 
-# create a seperate global Event listeners for each class
+
+def remove_value(prop, pseudo):
+    """
+    Remove a pseudo value and its content from a property
+    and cleanup the index of subsequent pseudo values to
+    make sure the view does not break.
+    :param prop: odml Property augmented to fit odml-ui.
+    :param pseudo: odmlui.treemodel.ValueModel.Value that should be
+                   removed from prop.
+    """
+    # Remove pseudo_value first.
+    del prop.pseudo_values[pseudo._index]
+    # Clean up indices of subsequent pseudovalues.
+    for pval in prop.pseudo_values[pseudo._index:]:
+        pval._index = pval._index - 1
+    # Finally remove the actual value from the property value list.
+    # Property.value always returns a copy so we need to modify and reassign
+    # the affected values.
+    cp_val = prop.value
+    del cp_val[pseudo._index]
+    prop._value = cp_val
+
+# create a separate global Event listeners for each class
 # and provide ModificationNotifier Capabilities
 name = "event"
 provides = odml.getImplementation().provides + ["event"]

--- a/odmlui/treemodel/event.py
+++ b/odmlui/treemodel/event.py
@@ -213,6 +213,14 @@ class ModificationNotifier(ChangeHandlable):
 
     def remove(self, obj):
         func = lambda: super(ModificationNotifier, self).remove(obj)
+
+        # Dirty Hack - if we are trying to remove a pseudo value from a property
+        # (both can be identified by having the 'pseudo_values' attribute), pass only
+        # the value itself, not the object. Otherwise property.remove() will
+        # try to remove the pseudo value, which of course it does not contain.
+        if hasattr(self, "pseudo_values") and hasattr(obj, "pseudo_values"):
+            func = lambda: remove_value(self, obj)
+
         self.__fireChange("remove", obj, func)
 
     def insert(self, position, obj):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 import glob
 import os
 
-from odmlui.info import VERSION, AUTHOR, CONTACT, HOMEPAGE, CLASSIFIERS
 # Use setuptools compulsorily, as the distutils doesn't work out well for the
 # installation procedure. The 'install_requires' and 'data_files' have better
 # support in setuptools.
@@ -14,6 +13,25 @@ try:
     kwargs.update({'console': ['odml-gui']})
 except ImportError:
     py2exe = None
+
+try:
+    from odml.info import AUTHOR, CONTACT, CLASSIFIERS, HOMEPAGE, VERSION
+except ImportError as ex:
+    # Read the information from odml.info.py if package dependencies
+    # are not yet available during a local install.
+    CLASSIFIERS = ""
+    with open('odml/info.py') as f:
+        for line in f:
+            curr_args = line.split(" = ")
+            if len(curr_args) == 2:
+                if curr_args[0] == "AUTHOR":
+                    AUTHOR = curr_args[1].replace('\'', '').replace('\\', '').strip()
+                elif curr_args[0] == "CONTACT":
+                    CONTACT = curr_args[1].replace('\'', '').strip()
+                elif curr_args[0] == "HOMEPAGE":
+                    HOMEPAGE = curr_args[1].replace('\'', '').strip()
+                elif curr_args[0] == "VERSION":
+                    VERSION = curr_args[1].replace('\'', '').strip()
 
 
 class PackageNotFoundError(Exception):

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import glob
+import json
 import os
 
 # Use setuptools compulsorily, as the distutils doesn't work out well for the
@@ -14,24 +15,14 @@ try:
 except ImportError:
     py2exe = None
 
-try:
-    from odml.info import AUTHOR, CONTACT, CLASSIFIERS, HOMEPAGE, VERSION
-except ImportError as ex:
-    # Read the information from odml.info.py if package dependencies
-    # are not yet available during a local install.
-    CLASSIFIERS = ""
-    with open('odml/info.py') as f:
-        for line in f:
-            curr_args = line.split(" = ")
-            if len(curr_args) == 2:
-                if curr_args[0] == "AUTHOR":
-                    AUTHOR = curr_args[1].replace('\'', '').replace('\\', '').strip()
-                elif curr_args[0] == "CONTACT":
-                    CONTACT = curr_args[1].replace('\'', '').strip()
-                elif curr_args[0] == "HOMEPAGE":
-                    HOMEPAGE = curr_args[1].replace('\'', '').strip()
-                elif curr_args[0] == "VERSION":
-                    VERSION = curr_args[1].replace('\'', '').strip()
+with open(os.path.join("odmlui/info.json")) as infofile:
+    infodict = json.load(infofile)
+
+VERSION = infodict["VERSION"]
+AUTHOR = infodict["AUTHOR"]
+CONTACT = infodict["CONTACT"]
+HOMEPAGE = infodict["HOMEPAGE"]
+CLASSIFIERS = infodict["CLASSIFIERS"]
 
 
 class PackageNotFoundError(Exception):
@@ -83,6 +74,7 @@ setup(name='odML-UI',
           }
       },
       install_requires=install_req,
+      include_package_data=True,
       entry_points={'gui_scripts': ['odmlui = odmlui.__main__:run []']},
       data_files=data_files,
       long_description=description_text,

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ try:
 except ImportError:
     py2exe = None
 
-with open(os.path.join("odmlui/info.json")) as infofile:
+with open(os.path.join("odmlui", "info.json")) as infofile:
     infodict = json.load(infofile)
 
 VERSION = infodict["VERSION"]


### PR DESCRIPTION
This PR fixes various breaking changes that were introduced in [python-odml](https://github.com/G-Node/python-odml).

- fixes appending and removing of values which was changed in python-odml.
- fixes the import of supported parsers which changed in python-odml as well.
- now uses the python-odml ODMLReader instead of the outdated JSONReader.
- fixes installation problems by introducing and using `json.info` in `setup.py` and `info.py`.
- fixes a bug on startup, when only a single monitor is present.
- adds MacOS conda disclaimer to `README`.
