### PR TITLE
Fixes for breaking changes in odml-core

### DIFF
--- a/odmlui/AttributeView.py
+++ b/odmlui/AttributeView.py
@@ -63,7 +63,7 @@ class AttributeView(TreeView):
             v = getattr(self._model, self._fmt.map(k))
             if not isinstance(v, list):
                 if v is not None:
-                    v = cgi.escape(v)
+                    v = cgi.escape(str(v))
 
                 # Exclude property attributes that are displayed in the
                 # PropertyView window.

--- a/odmlui/Editor.py
+++ b/odmlui/Editor.py
@@ -16,6 +16,8 @@ import odml
 import tempfile
 import odmlui.treemodel.mixin
 
+from odml.property import BaseProperty
+
 from odmlui.info import AUTHOR, CONTACT, COPYRIGHT, HOMEPAGE, VERSION, ODMLTABLES_VERSION
 from odmlui.treemodel import SectionModel, ValueModel
 
@@ -995,7 +997,7 @@ class EditorWindow(gtk.Window):
         # 2. select the corresponding section
         sec = obj
         prop = None
-        if isinstance(obj, odml.property.Property):
+        if isinstance(obj, BaseProperty):
             sec = obj.parent
             prop = obj
         self._section_tv.select_object(sec)

--- a/odmlui/Helpers.py
+++ b/odmlui/Helpers.py
@@ -74,24 +74,32 @@ def handle_section_import(section):
     """
     Augment all properties of an imported section according to odml-ui needs.
 
-    Every odml-ui property requires at least one default value according
-    to its dtype, otherwise the property is currently broken.
-    Further the properties are augmented with 'pseudo_values' which need to be
-    initialized and added to each property.
     :param section: imported odml.BaseSection
     """
     for prop in section.properties:
-        if len(prop._value) < 1:
-            if prop.dtype:
-                prop._value = [default_values(prop.dtype)]
-            else:
-                prop._value = [default_values('string')]
-
-        create_pseudo_values([prop])
+        handle_property_import(prop)
 
     # Make sure properties down the rabbit hole are also treated.
     for sec in section.sections:
         handle_section_import(sec)
+
+
+def handle_property_import(prop):
+    """
+    Every odml-ui property requires at least one default value according
+    to its dtype, otherwise the property is currently broken.
+    Further the properties are augmented with 'pseudo_values' which need to be
+    initialized and added to each property.
+
+    :param prop: imported odml.BaseProperty
+    """
+    if len(prop._value) < 1:
+        if prop.dtype:
+            prop._value = [default_values(prop.dtype)]
+        else:
+            prop._value = [default_values('string')]
+
+    create_pseudo_values([prop])
 
 
 def create_pseudo_values(odml_properties):

--- a/odmlui/Helpers.py
+++ b/odmlui/Helpers.py
@@ -4,7 +4,9 @@ import subprocess
 import sys
 
 from odml import fileio
+from odml.dtypes import default_values
 from odml.tools.parser_utils import SUPPORTED_PARSERS
+
 from .treemodel import ValueModel
 
 try:  # Python 3
@@ -66,6 +68,30 @@ def get_parser_for_file_type(file_type):
     if file_type not in SUPPORTED_PARSERS:
         parser = 'XML'
     return parser
+
+
+def handle_section_import(section):
+    """
+    Augment all properties of an imported section according to odml-ui needs.
+
+    Every odml-ui property requires at least one default value according
+    to its dtype, otherwise the property is currently broken.
+    Further the properties are augmented with 'pseudo_values' which need to be
+    initialized and added to each property.
+    :param section: imported odml.BaseSection
+    """
+    for prop in section.properties:
+        if len(prop._value) < 1:
+            if prop.dtype:
+                prop._value = [default_values(prop.dtype)]
+            else:
+                prop._value = [default_values('string')]
+
+        create_pseudo_values([prop])
+
+    # Make sure properties down the rabbit hole are also treated.
+    for sec in section.sections:
+        handle_section_import(sec)
 
 
 def create_pseudo_values(odml_properties):

--- a/odmlui/PropertyView.py
+++ b/odmlui/PropertyView.py
@@ -9,6 +9,8 @@ import odml.dtypes as dtypes
 import odml.terminology as terminology
 
 from odml import DType
+from odml.property import BaseProperty
+
 from . import commands
 from . import TextEditor
 from .DragProvider import DragProvider
@@ -57,8 +59,8 @@ class PropertyView(TerminologyPopupTreeView):
         pd = PropertyDrop(exec_func=_exec)
         sd = SectionDrop(exec_func=_exec)
         for target in [
-            OdmlDrag(mime="odml/property-ref", inst=odml.property.Property),
-            TextDrag(mime="odml/property", inst=odml.property.Property),
+            OdmlDrag(mime="odml/property-ref", inst=BaseProperty),
+            TextDrag(mime="odml/property", inst=BaseProperty),
             OdmlDrag(mime="odml/value-ref", inst=ValueModel.Value),
             TextDrag(mime="odml/value", inst=ValueModel.Value),
             TextDrag(mime="TEXT"),
@@ -114,7 +116,7 @@ class PropertyView(TerminologyPopupTreeView):
         self.on_property_select(obj)
 
         # Always expand multi value properties when selected
-        is_multi_value = isinstance(obj, odml.property.Property) and len(obj.value) > 1
+        is_multi_value = isinstance(obj, BaseProperty) and len(obj.value) > 1
         if is_multi_value:
             tree_selection.get_tree_view().expand_row(model.get_path(tree_iter), False)
 

--- a/odmlui/SectionView.py
+++ b/odmlui/SectionView.py
@@ -4,6 +4,8 @@ import odml
 pygtkcompat.enable()
 pygtkcompat.enable_gtk(version='3.0')
 
+from odml.section import BaseSection
+
 from . import commands
 from .DragProvider import DragProvider
 from .dnd.odmldrop import OdmlDrag, OdmlDrop
@@ -30,8 +32,8 @@ class SectionView(TerminologyPopupTreeView):
         pd = PropertyDrop(exec_func=_exec)
         sd = SectionDrop(exec_func=_exec)
         for target in [
-                OdmlDrag(mime="odml/section-ref", inst=odml.section.Section),
-                TextDrag(mime="odml/section", inst=odml.section.Section),
+                OdmlDrag(mime="odml/section-ref", inst=BaseSection),
+                TextDrag(mime="odml/section", inst=BaseSection),
                 TextDrag(mime="TEXT"),
                 OdmlDrop(mime="odml/property-ref", target=pd, registry=registry,
                          exec_func=_exec),
@@ -109,7 +111,7 @@ class SectionView(TerminologyPopupTreeView):
         self.execute(cmd)
 
         # Expand tree if the parent object is a section
-        if isinstance(obj, odml.section.Section):
+        if isinstance(obj, BaseSection):
             tv = self._treeview
             (model, tree_iter) = tv.get_selection().get_selected()
             tv.expand_row(model.get_path(tree_iter), False)

--- a/odmlui/SectionView.py
+++ b/odmlui/SectionView.py
@@ -11,6 +11,7 @@ from .DragProvider import DragProvider
 from .dnd.odmldrop import OdmlDrag, OdmlDrop
 from .dnd.targets import PropertyDrop, SectionDrop
 from .dnd.text import TextDrag, TextDrop, TextGenericDropForSectionTV
+from .Helpers import handle_section_import
 from .TreeView import TerminologyPopupTreeView
 
 
@@ -105,6 +106,9 @@ class SectionView(TerminologyPopupTreeView):
 
             # It is a terminology section. By default, pull in all its properties.
             section.merge()
+
+            # All added properties need to be adjusted to odml-ui needs!
+            handle_section_import(section)
 
         cmd = commands.AppendValue(obj=obj, val=section)
 

--- a/odmlui/Wizard.py
+++ b/odmlui/Wizard.py
@@ -7,6 +7,10 @@ pygtkcompat.enable_gtk(version='3.0')
 import gtk
 import odml
 import odml.terminology as terminology
+
+from odml.dtypes import default_values
+
+from .Helpers import create_pseudo_values
 from .treemodel.SectionModel import SectionModel
 from .SectionView import SectionView
 from .ScrolledWindow import ScrolledWindow
@@ -245,7 +249,17 @@ class DocumentWizard:
                     continue
                 newsec = sec.clone(children=False)
                 for prop in sec.properties:
-                    newsec.append(prop.clone())
+                    # Every prop requires at least one default value according to its
+                    # dtype otherwise the property is currently broken.
+                    cprop = prop.clone()
+                    if len(cprop._value) < 1:
+                        if cprop.dtype:
+                            cprop._value = [default_values(cprop.dtype)]
+                        else:
+                            cprop._value = [default_values('string')]
+
+                    newsec.append(cprop)
+
                 sec._assoc_sec = newsec
                 if hasattr(sec.parent, "_assoc_sec"):
                     sec.parent._assoc_sec.append(newsec)

--- a/odmlui/Wizard.py
+++ b/odmlui/Wizard.py
@@ -8,9 +8,7 @@ import gtk
 import odml
 import odml.terminology as terminology
 
-from odml.dtypes import default_values
-
-from .Helpers import create_pseudo_values
+from .Helpers import handle_property_import
 from .treemodel.SectionModel import SectionModel
 from .SectionView import SectionView
 from .ScrolledWindow import ScrolledWindow
@@ -249,19 +247,10 @@ class DocumentWizard:
                     continue
                 newsec = sec.clone(children=False)
                 for prop in sec.properties:
-                    # Every prop requires at least one default value according to its
-                    # dtype otherwise the property is currently broken.
                     cprop = prop.clone()
-                    if len(cprop._value) < 1:
-                        if cprop.dtype:
-                            cprop._value = [default_values(cprop.dtype)]
-                        else:
-                            cprop._value = [default_values('string')]
 
-                    # odml-ui properties are augmented with 'pseudo_values'.
-                    # When creating the properties for the current document,
-                    # make sure the pseudo_values are also initialized and added.
-                    create_pseudo_values([cprop])
+                    # All added properties need to be adjusted to odml-ui needs!
+                    handle_property_import(cprop)
 
                     newsec.append(cprop)
 

--- a/odmlui/Wizard.py
+++ b/odmlui/Wizard.py
@@ -258,6 +258,11 @@ class DocumentWizard:
                         else:
                             cprop._value = [default_values('string')]
 
+                    # odml-ui properties are augmented with 'pseudo_values'.
+                    # When creating the properties for the current document,
+                    # make sure the pseudo_values are also initialized and added.
+                    create_pseudo_values([cprop])
+
                     newsec.append(cprop)
 
                 sec._assoc_sec = newsec

--- a/odmlui/dnd/targets.py
+++ b/odmlui/dnd/targets.py
@@ -1,5 +1,9 @@
 import odml
+
+from odml.base import Sectionable
+
 from .. import commands
+
 
 class ActionDrop(object):
     """
@@ -74,6 +78,6 @@ class SectionDrop(GenericDrop):
         * can only move/copy into Sections/Documents
         """
         if action.link: return isinstance(dst, odml.section.Section)
-        return isinstance(dst, odml.base.sectionable)
+        return isinstance(dst, Sectionable)
 
 # TODO make links / include from other apps work

--- a/odmlui/dnd/targets.py
+++ b/odmlui/dnd/targets.py
@@ -1,6 +1,7 @@
 import odml
 
 from odml.base import Sectionable
+from odml.property import BaseProperty
 from odml.section import BaseSection
 
 from .. import commands
@@ -37,7 +38,7 @@ class ValueDrop(GenericDrop):
         can only move/copy into Properties
         """
         if action.link: return False
-        return isinstance(dst, odml.property.Property)
+        return isinstance(dst, BaseProperty)
 
 class PropertyDrop(GenericDrop):
     def get_drop_dest(self, dst, action):

--- a/odmlui/dnd/targets.py
+++ b/odmlui/dnd/targets.py
@@ -1,6 +1,7 @@
 import odml
 
 from odml.base import Sectionable
+from odml.section import BaseSection
 
 from .. import commands
 
@@ -41,7 +42,7 @@ class ValueDrop(GenericDrop):
 class PropertyDrop(GenericDrop):
     def get_drop_dest(self, dst, action):
         if action.link: return None
-        while not isinstance(dst, odml.section.Section):
+        while not isinstance(dst, BaseSection):
             dst = dst.parent
         return dst
 
@@ -50,7 +51,7 @@ class PropertyDrop(GenericDrop):
         can only move/copy into Sections
         """
         if action.link: return False
-        return isinstance(dst, odml.section.Section)
+        return isinstance(dst, BaseSection)
 
 class SectionDrop(GenericDrop):
     def drop_object(self, action, dst, position, obj):
@@ -77,7 +78,7 @@ class SectionDrop(GenericDrop):
         * can only establish links to Sections
         * can only move/copy into Sections/Documents
         """
-        if action.link: return isinstance(dst, odml.section.Section)
+        if action.link: return isinstance(dst, BaseSection)
         return isinstance(dst, Sectionable)
 
 # TODO make links / include from other apps work

--- a/odmlui/dnd/text.py
+++ b/odmlui/dnd/text.py
@@ -4,13 +4,15 @@ pygtkcompat.enable_gtk(version='3.0')
 
 import gtk
 
+import odml
+import odml.tools.xmlparser as xmlparser
+
+from odml.section import BaseSection
+
 from . import odmldrop
 from . import tree
 from .targets import *
 from ..treemodel import ValueModel
-
-import odml
-import odml.tools.xmlparser as xmlparser
 
 class TextDrop(odmldrop.OdmlTreeDropTarget):
     """
@@ -53,7 +55,7 @@ class TextGenericDrop(TextDrop, SectionDrop, PropertyDrop, ValueDrop):
         for kls, tkls in [
             (ValueModel.Value, ValueDrop),
             (odml.property.Property, PropertyDrop),
-            (odml.section.Section, SectionDrop)
+            (BaseSection, SectionDrop)
             ]:
             if not kls in self.targets:
                 continue
@@ -79,7 +81,7 @@ class TextGenericDropForPropertyTV(TextGenericDrop):
         if isinstance(obj, ValueModel.Value) and not isinstance(dst, odml.property.Property):
             return False
         # can't drop properties to anything but sections
-        if isinstance(obj, odml.property.Property) and not isinstance(dst, odml.section.Section):
+        if isinstance(obj, odml.property.Property) and not isinstance(dst, BaseSection):
             return False
         return True
 
@@ -88,7 +90,7 @@ class TextGenericDropForSectionTV(TextGenericDropForPropertyTV):
     can drop Properties and Section, inherited is the capability to only drop
     Properties into Sections (not into Documents)
     """
-    targets = [odml.property.Property, odml.section.Section]
+    targets = [odml.property.Property, BaseSection]
 
 class TextDrag(odmldrop.OdmlDrag):
     """

--- a/odmlui/dnd/text.py
+++ b/odmlui/dnd/text.py
@@ -4,9 +4,9 @@ pygtkcompat.enable_gtk(version='3.0')
 
 import gtk
 
-import odml
 import odml.tools.xmlparser as xmlparser
 
+from odml.property import BaseProperty
 from odml.section import BaseSection
 
 from . import odmldrop
@@ -54,7 +54,7 @@ class TextGenericDrop(TextDrop, SectionDrop, PropertyDrop, ValueDrop):
     def drop_object(self, action, dst, position, obj):
         for kls, tkls in [
             (ValueModel.Value, ValueDrop),
-            (odml.property.Property, PropertyDrop),
+            (BaseProperty, PropertyDrop),
             (BaseSection, SectionDrop)
             ]:
             if not kls in self.targets:
@@ -73,15 +73,15 @@ class TextGenericDropForPropertyTV(TextGenericDrop):
     can drop Properties and Values, but only Values into Properties
     and Properties into Sections
     """
-    targets = [odml.property.Property, ValueModel.Value]
+    targets = [BaseProperty, ValueModel.Value]
     def text_can_drop(self, action, dst, position, obj):
         if not super(TextGenericDropForPropertyTV, self).text_can_drop(action, dst, position, obj):
             return False
         # can't drop values to anything but properties
-        if isinstance(obj, ValueModel.Value) and not isinstance(dst, odml.property.Property):
+        if isinstance(obj, ValueModel.Value) and not isinstance(dst, BaseProperty):
             return False
         # can't drop properties to anything but sections
-        if isinstance(obj, odml.property.Property) and not isinstance(dst, BaseSection):
+        if isinstance(obj, BaseProperty) and not isinstance(dst, BaseSection):
             return False
         return True
 
@@ -90,7 +90,7 @@ class TextGenericDropForSectionTV(TextGenericDropForPropertyTV):
     can drop Properties and Section, inherited is the capability to only drop
     Properties into Sections (not into Documents)
     """
-    targets = [odml.property.Property, BaseSection]
+    targets = [BaseProperty, BaseSection]
 
 class TextDrag(odmldrop.OdmlDrag):
     """

--- a/odmlui/treemodel/PropertyModel.py
+++ b/odmlui/treemodel/PropertyModel.py
@@ -3,8 +3,8 @@ pygtkcompat.enable()
 pygtkcompat.enable_gtk(version='3.0')
 
 import odml
-import odml.property
 
+from odml.property import BaseProperty
 from odml.section import BaseSection
 
 from .TreeIters import PropIter, ValueIter, SectionPropertyIter
@@ -76,7 +76,7 @@ class PropertyModel(TreeModel):
         return super(PropertyModel, self).on_iter_nth_child(tree_iter, n)
 
     def _get_node_iter(self, node):
-        if isinstance(node, odml.property.Property):
+        if isinstance(node, BaseProperty):
             return PropIter(node)
         if isinstance(node, ValueModel.Value):
             return ValueIter(node)
@@ -84,7 +84,7 @@ class PropertyModel(TreeModel):
 
     def post_delete(self, parent, old_path):
         super(PropertyModel, self).post_delete(parent, old_path)
-        if isinstance(parent, odml.property.Property):
+        if isinstance(parent, BaseProperty):
             # a value was deleted
             if len(parent) == 1:
                 # the last child row is also not present anymore,

--- a/odmlui/treemodel/PropertyModel.py
+++ b/odmlui/treemodel/PropertyModel.py
@@ -5,6 +5,8 @@ pygtkcompat.enable_gtk(version='3.0')
 import odml
 import odml.property
 
+from odml.section import BaseSection
+
 from .TreeIters import PropIter, ValueIter, SectionPropertyIter
 from .TreeModel import TreeModel, ColumnMapper
 from . import ValueModel
@@ -106,7 +108,7 @@ class PropertyModel(TreeModel):
         # we are only interested in changes going up to the section level,
         # but not those dealing with subsections of ours
         if context.cur is not self._section or \
-                isinstance(context.val, odml.section.Section):
+                isinstance(context.val, BaseSection):
             return
 
         if context.action == "set" and context.post_change:

--- a/odmlui/treemodel/SectionModel.py
+++ b/odmlui/treemodel/SectionModel.py
@@ -4,9 +4,9 @@ pygtkcompat.enable_gtk(version='3.0')
 
 import gtk, gobject
 import odmlui
-import odml.doc
 
 from odml.base import Sectionable
+from odml.doc import BaseDocument
 
 from .TreeIters import SectionIter
 from .TreeModel import TreeModel, ColumnMapper
@@ -22,7 +22,7 @@ class SectionModel(TreeModel):
         super(SectionModel, self).__init__(ColMapper)
 
         # otherwise bad things happen
-        assert isinstance(odml_document, odml.doc.Document)
+        assert isinstance(odml_document, BaseDocument)
 
         self._section = odml_document
         self._section.add_change_handler(self.on_section_changed)

--- a/odmlui/treemodel/SectionModel.py
+++ b/odmlui/treemodel/SectionModel.py
@@ -5,7 +5,9 @@ pygtkcompat.enable_gtk(version='3.0')
 import gtk, gobject
 import odmlui
 import odml.doc
-import odml.base
+
+from odml.base import Sectionable
+
 from .TreeIters import SectionIter
 from .TreeModel import TreeModel, ColumnMapper
 debug = lambda x: 0
@@ -94,7 +96,7 @@ class SectionModel(TreeModel):
             print("change event(section): ", context)
 
         # we are only interested in changes on sections
-        if not isinstance(context.obj, odml.base.sectionable): return
+        if not isinstance(context.obj, Sectionable): return
         if not context.cur.document is self.document: return
 
         if context.action == "set" and context.post_change:
@@ -107,7 +109,7 @@ class SectionModel(TreeModel):
             self.event_reorder(context)
 
         obj = context.val
-        if not isinstance(obj, odml.base.sectionable): return
+        if not isinstance(obj, Sectionable): return
 
         if context.action == "remove":
             self.event_remove(context)

--- a/odmlui/treemodel/ValueModel.py
+++ b/odmlui/treemodel/ValueModel.py
@@ -1,8 +1,10 @@
 # -*- coding: utf8
 
-import odml.base as base
 import odml.format as format
 import odml.dtypes as dtypes
+
+from odml.base import BaseObject
+
 from . import nodes, event
 
 
@@ -20,7 +22,7 @@ class ValueFormat(format.Format):
     _map = {}
 
 
-class Value(base.baseobject, base._baseobj, ValueNode, event.ModificationNotifier):
+class Value(BaseObject, ValueNode, event.ModificationNotifier):
     """
     Since the odML value node has been merged with the odml.Property, and is
     only available as a 'pure' python list we cannot render it to the Editor
@@ -133,6 +135,6 @@ class Value(base.baseobject, base._baseobj, ValueNode, event.ModificationNotifie
         return self._reorder(self.parent.value, new_index)
 
     def clone(self):
-        obj = base.baseobject.clone(self)
+        obj = BaseObject.clone(self)
         obj._property = None
         return obj

--- a/odmlui/treemodel/nodes.py
+++ b/odmlui/treemodel/nodes.py
@@ -4,7 +4,8 @@ Document, Section, Property and Value.
 
 Additionally implements change notifications up to the corresponding section.
 """
-import odml.property
+from odml.property import BaseProperty
+
 from . import event
 
 
@@ -109,7 +110,7 @@ class SectionNode(ParentedNode):
         return child.from_path(path[2:])
 
     def path_to(self, child):
-        if isinstance(child, odml.property.Property):
+        if isinstance(child, BaseProperty):
             return 1, identity_index(self._props, child)
         return 0, identity_index(self._sections, child)
 


### PR DESCRIPTION
This PR dramatically decreases the red comments on the command line by catching up with the breaking changes introduced in [odml-core](https://github.com/G-Node/python-odml).

- Adjusts to the flattened inheritance in odml-core.
- The document date is now a proper date in odml-core. odml-ui now no longer fails on parsing the document date.
- For display purposes Property values are treated specially in odml-ui. This PR introduces various fixes in the Wizard and the SectionView context menu where terminology sections are imported. All child properties have to be modified to contain at least one default value and require `pseudo_values` referencing these values to make sure the document tree is not broken after the terminology import. Closes #107 and should also fix #91.
