### PR TITLE
[1.4] Add import feature for odML format v1.0 files

### DIFF
--- a/odmlui/Editor.py
+++ b/odmlui/Editor.py
@@ -44,6 +44,7 @@ ui_info = \
     <menu name='FileMenu' action='FileMenu'>
       <menuitem action='NewFile'/>
       <menuitem action='FileOpen'/>
+      <menuitem action='Import'/>
       <menuitem action='OpenRecent' />
       <menuitem name='Save' action='Save' />
       <menuitem action='SaveAs' />
@@ -546,6 +547,12 @@ class EditorWindow(gtk.Window):
 
         self.append_tab(tab)
         return tab
+
+    @gui_action("Import", tooltip="Import previous odML version", label="Import odML")
+    def import_file(self, action):
+        """Open a file chooser dialog to import a previous odML version file."""
+        self.chooser_dialog(title="Import previous odML version",
+                            callback=self.convert_version)
 
     def convert_version(self, uri, file_type=None):
         """

--- a/odmlui/Editor.py
+++ b/odmlui/Editor.py
@@ -547,6 +547,18 @@ class EditorWindow(gtk.Window):
         self.append_tab(tab)
         return tab
 
+    def convert_version(self, uri, file_type=None):
+        """
+        Open a new tab, and load a previous version odML file into it.
+        """
+        tab = EditorTab(self)
+        if not tab.convert(uri):  # Close tab upon parsing errors
+            tab.close()
+            return
+
+        self.append_tab(tab)
+        return tab
+
     @gui_action("CloneTab", tooltip="Create a copy of the current tab", label="_Clone",
                 stock_id=gtk.STOCK_COPY, accelerator="<control><shift>C")
     def on_clone_tab(self, action):

--- a/odmlui/EditorTab.py
+++ b/odmlui/EditorTab.py
@@ -8,6 +8,8 @@ import os.path
 import odml
 import odml.validation
 from odml.tools.odmlparser import ODMLReader, ODMLWriter
+from odml.tools.parser_utils import InvalidVersionException
+from odml.tools.version_converter import VersionConverter
 
 from .CommandManager import CommandManager
 from .Helpers import uri_to_path, get_parser_for_uri, get_extension, \
@@ -61,6 +63,15 @@ class EditorTab(object):
         odml_reader = ODMLReader(parser=parser)
         try:
             self.document = odml_reader.from_file(file_path)
+        except InvalidVersionException as inver:
+            _, curr_file = os.path.split(file_path)
+            err_header = "Cannot open file '%s'." % curr_file
+            err_msg = ("You are trying to open an odML file of an outdated format. "
+                       "\n\nUse 'File .. import' to convert and open files of "
+                       "a previous odML format.")
+            ErrorDialog(self.window, err_header, err_msg)
+            return False
+
         except Exception as e:
             ErrorDialog(self.window, "Error parsing '%s'" % file_path, str(e))
             if len(self.window.notebook) < 1:

--- a/odmlui/EditorTab.py
+++ b/odmlui/EditorTab.py
@@ -85,6 +85,14 @@ class EditorTab(object):
         return True
 
     def convert(self, uri):
+        """
+        Convert a previous odML version to the current one. If the file can be
+        successfully converted, it is saved with the old filename and the
+        postfix '_converted' in the xml format and immediately loaded into a new tab.
+
+        :param uri: uri of the conversion candidate file.
+        :return: True if loading worked, False if any conversion or loading errors occur.
+        """
         file_path = uri_to_path(uri)
         parser = get_parser_for_uri(file_path)
         vconv = VersionConverter(file_path)

--- a/odmlui/EditorTab.py
+++ b/odmlui/EditorTab.py
@@ -104,7 +104,8 @@ class EditorTab(object):
 
         # TODO display conversion warnings
 
-        return True
+        # When we have written, we can load!
+        return self.load(new_file_path)
 
     def reset(self):
         self.edited = 0  # initialize the edit stack position

--- a/odmlui/EditorTab.py
+++ b/odmlui/EditorTab.py
@@ -85,6 +85,14 @@ class EditorTab(object):
         return True
 
     def convert(self, uri):
+        file_path = uri_to_path(uri)
+
+        # Currently we can only convert to xml out of the box,
+        # so don't bother about the extension.
+        file_name = os.path.basename(file_path)
+        new_file_name = "%s_converted.xml" % os.path.splitext(file_name)[0]
+        new_file_path = os.path.join(os.path.dirname(file_path), new_file_name)
+
         return True
 
     def reset(self):

--- a/odmlui/EditorTab.py
+++ b/odmlui/EditorTab.py
@@ -84,6 +84,9 @@ class EditorTab(object):
         self.window._info_bar.show_info("Loading of %s done!" % (os.path.basename(file_path)))
         return True
 
+    def convert(self, uri):
+        return True
+
     def reset(self):
         self.edited = 0  # initialize the edit stack position
         self.command_manager.reset()

--- a/odmlui/EditorTab.py
+++ b/odmlui/EditorTab.py
@@ -86,12 +86,23 @@ class EditorTab(object):
 
     def convert(self, uri):
         file_path = uri_to_path(uri)
+        parser = get_parser_for_uri(file_path)
+        vconv = VersionConverter(file_path)
 
         # Currently we can only convert to xml out of the box,
         # so don't bother about the extension.
         file_name = os.path.basename(file_path)
         new_file_name = "%s_converted.xml" % os.path.splitext(file_name)[0]
         new_file_path = os.path.join(os.path.dirname(file_path), new_file_name)
+
+        try:
+            vconv.write_to_file(new_file_path, parser)
+        except Exception as err:
+            err_header = "Error converting file '%s'." % file_name
+            ErrorDialog(self.window, err_header, str(err))
+            return False
+
+        # TODO display conversion warnings
 
         return True
 

--- a/odmlui/info.json
+++ b/odmlui/info.json
@@ -13,5 +13,5 @@
     "Intended Audience :: Science/Research",
     "Intended Audience :: End Users/Desktop"
   ],
-  "ODMLTABLES_VERSION": "1.2.0"
+  "ODMLTABLES_VERSION": "1.0.0"
 }


### PR DESCRIPTION
This PR introduces import of odML format v1.0 files. Depends on G-Node/python-odml#285.
