### PR TITLE
External fix for using conda and MacOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,119 @@
 Used to document all changes from previous releases and collect changes 
 until the next release.
 
+
+# Version 1.4.0
+## Breaking changes
+
+This release depends on [python-odml v1.4.0](
+https://github.com/G-Node/python-odml/releases/tag/v1.4.0) which was a breaking change 
+from v1.3. Due to this fact the current version is partially incompatible with the 
+previous releases.
+
+### Import of previous format odML files
+odML files with file format "1" cannot be normally opened with the current release of 
+odml-ui. They have to be converted into the new format using the `File - Import` feature, 
+which will create, save and open a new, odML v1.4 compatible file. The original file 
+remains untouched to ensure that no information is lost due to the conversion. See #127.
+
+### 'Value' handling
+- The `Value` attributes `encoder` and `checksum` have been removed.
+- The `Value` attributes `unit`, `uncertainty`, `type` and `reference` can now only be 
+    specified once for a Property.
+- The `Value` attribute `filename` has been renamed to `value_origin`.
+- The `Value` odML datatype `binary` has been removed. Adding binary content to odML 
+    files is discouraged in lieu of providing the `URL` to the original file containing 
+    the actual content.
+
+### Mapping has been removed
+Any mapping functionality has been removed from odml-ui. See #84.
+
+## Features and updates
+- Adds a confirmation dialog when `Save as` would replace an existing file. See #74.
+- The validation is now always run before saving and only a valid odML file may be saved. 
+    Otherwise the validation window with the encountered validation errors is displayed. 
+    See #58.
+- The default odML terminology repository used in the document wizard has been changed 
+    to `http://portal.g-node.org/odml/terminologies/v1.1/terminologies.xml`.
+- When a new document is created, the corresponding tab is automatically 
+    selected. See #71.
+- When a section with children sections is selected in the "Section View", this section 
+    is now automatically expanded. See #73.
+- A selected property now always expands, if it contains multiple values. See #70.
+- The content of all multiple values can be voluntarily overwritten when the value entry 
+    of the parent Property is set.
+- Removes the wizard intro page; See #103 
+- Increases the "Validation Window" size. See #75.
+- Uses different main app starting window sizes (800x600 or 1024x768) depending on the 
+    available screen size. See #113.
+- Adjusts the height of the "Attribute View" to always display all attributes. See #113.
+- Reorders the "Property View" columns; See #89.
+
+### The odmtables plugin
+- odml-ui provides access to [python-odmltables](
+    https://github.com/INM-6/python-odmltables).
+- odml-ui does not require odmltables to be installed, but rather provides buttons to 
+    open the current odML document with the selected odmltables wizard plugins at all 
+    times. If the required odmltables version cannot be found, an appropriate install 
+    required version message is displayed. If odmltables is installed in the required 
+    version, the selected wizard is opened in a new window with the odML document from 
+    the currently active odml-ui tab.
+- The currently supported odmltables wizard plugins are `compare`, `convert`, `filter` 
+    and `merge`.
+- Currently odmltables only supports XML files with the file ending `.odml`. Therefore, 
+    any odML document that is passed from odml-ui to one of the supported odmltables 
+    wizards is saved as an XML file with the ".odml" file ending in the temporary odML 
+    folder also used for the terminologies and then passed along to odmltables.
+
+## Fixes
+- Fixes various breaking changes introduced in python-odml during the v1.3 - v1.4 
+    transition. See #120 and #124.
+- Fixes that all files were saved as `XML`, even when the `JSON` or `YAML` formats had 
+    been selected. See #62.
+- Fixes that all multiple values of a Property can be overwritten by the `pseudo_value` 
+    placeholder text `n/a` by just escaping the edit state. See #69.
+- Fixes that multiple values of a Property were only accessible after a refresh of the 
+    "Property View". See #64.
+- Fixes a Value error when its content was starting with "<". See #65
+- Fixes the Wizard author display. See #53.
+- Fixes missing size refresh of the "Validation Window" when the content tree has 
+    updated. See #67.
+- Fixes inactive entry selection in the "Validation Window". See #68.
+- Fixes that loading of an invalid odML file leads to a broken document. See #57.
+- Fixes an `AttributeError` when opening the validation window. See #60.
+- Fixes an error message display in `EditorTab` on fail to save. See #66.
+- Fixes Wizard crashes on empty repository and missing parent section. See #66.
+- Fixes missing `create_pseudo_value` import in `EditorTab`. See #66.
+- Fixes the validation warning character display for Python 2. See #75.
+- Fixes "Section View" and "Property View" update issues when creating empty documents and 
+    switching tabs. See #72 and #81.
+- Removes a hardcoded breakpoint to avoid application freeze; See #108.
+- Refactors code to avoid GTK deprecation warnings; See #98.
+
+
+# Version 1.3.2
+## Updates to dependency version handling
+- In the light of future, incompatible versions of python-odml, the python-odml dependency 
+    now supports a version number range (>=1.3.3, <1.4.*) on install.
+- The same is true for the optional plug-in [odml-tables](
+    https://github.com/INM-6/python-odmltables/) with the supported version number 
+    range >=0.2.0, <=0.9.9)
+
+Depends on [python-odml v1.3.4](https://github.com/G-Node/python-odml/releases/tag/v1.3.4).
+
+
+# Version 1.3.1
+## Fixes
+- Single monitor startup bug.
+- Potential installation issues due to import from `info.py`.
+- Readme updates regarding MacOS conda installation.
+
+Depends on [python-odml v1.3.4](https://github.com/G-Node/python-odml/releases/tag/v1.3.4).
+
+
+# Version 1.3.0
+First viable release since the UI functionality has been extracted from [python-odml](
+    https://github.com/G-Node/python-odml).
+
+Depends on python-odml v1.3.3.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+Used to document all changes from previous releases and collect changes 
+until the next release.
+

--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,20 @@ For details regarding the introduced changes please check the `github release no
 <https://github.com/G-Node/odml-ui/releases>`_.
 
 
+Release Versions
+----------------
+All released versions are distributed via the `Python Package Index`_ and can
+be installed using pip_::
+
+    $ pip install odml-ui
+
+Once installed, the program can be activated via the command line:
+
+    $ odmlui
+
+Note: It might be required to install the external GTK3 dependencies first.
+
+
 Dependencies
 ------------
 
@@ -62,10 +76,10 @@ Anaconda environments require only the following packages before installing the 
 
 NOTE: These packages currently only work on Linux out of the box!
 
-The MacOS installation of these 3rd party dependencies contain a bug which causes
+The macOS installation of these 3rd party dependencies contain a bug which causes
 the opening of any window selecting files to crash the application.
 
-If you still want to use odmlui with conda on MacOS, you currently need to
+If you still want to use odmlui with conda on macOS, you currently need to
 apply a manual fix at the start of your session in your active conda environment
 to avert this crash:
 
@@ -76,8 +90,8 @@ required environment variable at the start of a conda session as described in th
 <https://conda.io/docs/user-guide/tasks/manage-environments.html#macos-linux-save-env-variables>`_.
 
 
-MacOS using homebrew:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+macOS using homebrew:
+~~~~~~~~~~~~~~~~~~~~~
 For Python 2 (Python 3)
 
 * :code:`brew install gtk+ (gtk+3)`
@@ -86,8 +100,8 @@ For Python 2 (Python 3)
 * :code:`brew install gobject-introspection`
 
 
-Installation
-------------
+Installation from source
+------------------------
 
 To download the odML-Editor, please either use git and clone the 
 repository from GitHub::

--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,21 @@ Anaconda environments require only the following packages before installing the 
     $ conda install -c conda-forge gdk-pixbuf
     $ conda install -c pkgw-forge adwaita-icon-theme
 
-These dependencies currently only work on Linux, MacOS is not supported!
+NOTE: These dependencies currently only work on Linux out of the box!
+
+The MacOS installation of these 3rd party dependencies contain a bug which causes
+the opening of any window selecting files to crash the application.
+
+If you still want to use odmlui with conda on MacOS, you currently need to
+apply a manual fix at the start of you session in your activate conda environment
+to avert this crash:
+
+:code:`export GSETTINGS_SCHEMA_DIR=$CONDA_PREFIX/share/glib-2.0/schemas`
+
+You can also add scripts to your conda environment that always automatically sets up the
+required environment variable at the start of a conda session as described in the `conda documentation
+<https://conda.io/docs/user-guide/tasks/manage-environments.html#macos-linux-save-env-variables>`_.
+
 
 MacOS using homebrew:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -103,8 +103,9 @@ For Python 2 (Python 3)
 Installation from source
 ------------------------
 
-To download the odML-Editor, please either use git and clone the 
-repository from GitHub::
+The most straightforward way to get to the odML-Editor source from
+the command line is to use git and clone the repository from GitHub
+into your directory of choice::
 
   $ cd /home/usr/toolbox/
   $ git clone https://github.com/G-Node/odml-ui.git

--- a/README.rst
+++ b/README.rst
@@ -60,13 +60,13 @@ Anaconda environments require only the following packages before installing the 
     $ conda install -c conda-forge gdk-pixbuf
     $ conda install -c pkgw-forge adwaita-icon-theme
 
-NOTE: These dependencies currently only work on Linux out of the box!
+NOTE: These packages currently only work on Linux out of the box!
 
 The MacOS installation of these 3rd party dependencies contain a bug which causes
 the opening of any window selecting files to crash the application.
 
 If you still want to use odmlui with conda on MacOS, you currently need to
-apply a manual fix at the start of you session in your activate conda environment
+apply a manual fix at the start of your session in your active conda environment
 to avert this crash:
 
 :code:`export GSETTINGS_SCHEMA_DIR=$CONDA_PREFIX/share/glib-2.0/schemas`

--- a/README.rst
+++ b/README.rst
@@ -109,8 +109,10 @@ required GObject introspection library.
 
 Documentation
 -------------
-odML related documentation can be found at the
-`Python-odML <http://g-node.github.io/python-odml>`_ tutorial page.
+
+More information about the project including related projects as well as tutorials and
+examples can be found at our `odML project page <https://g-node.github.io/python-odml>`_
+
 
 Bugs & Questions
 ----------------

--- a/odmlui/Editor.py
+++ b/odmlui/Editor.py
@@ -1088,12 +1088,15 @@ def get_img_path(icon_name):
 
 
 def register_stock_icons():
-    # conda environments might not have access to the system stock items.
-    # Therefore update the IconTheme search path.
-    if conda_env_root:
-        print("[Info] Updating IconTheme search path")
-        icon_theme = gtk.icon_theme_get_default()
-        icon_theme.prepend_search_path(os.path.join(conda_env_root, "share", "icons"))
+
+    # virtual or conda environments as well as local installs might
+    # not have access to the system stock items so we update the IconTheme search path.
+    print("[Info] Updating IconTheme search paths")
+    icon_theme = gtk.icon_theme_get_default()
+
+    icon_paths = lookup_resource_paths(os.path.join('share', 'icons'))
+    for ipath in icon_paths:
+        icon_theme.prepend_search_path(ipath)
 
     ctrlshift = gtk.gdk.CONTROL_MASK | gtk.gdk.SHIFT_MASK
     icons = [('odml-logo', '_odML', 0, 0, ''),

--- a/odmlui/Helpers.py
+++ b/odmlui/Helpers.py
@@ -120,16 +120,19 @@ def get_conda_root():
     """
     root_path = ""
     try:
+        # Try identifying conda the easy way
+        if "CONDA_PREFIX" in os.environ:
+            return os.environ["CONDA_PREFIX"]
+
+        # Try identifying conda the hard way
         conda_json = subprocess.check_output("conda info --json",
                                              shell=True, stderr=subprocess.PIPE)
         if sys.version_info.major > 2:
             conda_json = conda_json.decode("utf-8")
-
         dec = json.JSONDecoder()
         root_path = dec.decode(conda_json)['default_prefix']
         if sys.version_info.major < 3:
             root_path = str(root_path)
-
     except Exception as ex:
         print("[Info] Conda check: %s" % ex)
 


### PR DESCRIPTION
This tiny PR adds a Changelog and a notice how to unbreak using odmlui with conda on macOS.

Furthermore the icon search path is now updated for system wide, local, virtualenv and conda installs as well. This should fix #128.

The README now contains a pip install notice and how to start odml-ui from the command line once it is installed.