### PR TITLE
Welcome page and active icon handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Used to document all changes from previous releases and collect changes 
 until the next release.
 
+# Latest changes in master
+
+- Icon search path update. See #130
+
 
 # Version 1.4.0
 ## Breaking changes

--- a/odmlui/Editor.py
+++ b/odmlui/Editor.py
@@ -536,6 +536,7 @@ class EditorWindow(gtk.Window):
         if wizard:
             wiz = DocumentWizard()
             wiz.finish = lambda doc: self.new_file(wizard=False, doc=doc)
+            wiz.cleanup = self.set_welcome
             return
 
         tab = EditorTab(self)

--- a/odmlui/Editor.py
+++ b/odmlui/Editor.py
@@ -499,6 +499,14 @@ class EditorWindow(gtk.Window):
 
         return True
 
+    def set_welcome(self):
+        """
+        Run the welcome action in case there is no open tab.
+        Required when cancelling or failing on a wizard or an open file dialog.
+        """
+        if len(self.notebook) < 1:
+            self.welcome()
+
     @gui_action("About", tooltip="About odML editor", stock_id=gtk.STOCK_ABOUT)
     def about(self, action):
         logo = self.render_icon("odml-logo", gtk.ICON_SIZE_DIALOG)

--- a/odmlui/Editor.py
+++ b/odmlui/Editor.py
@@ -183,9 +183,9 @@ class EditorWindow(gtk.Window):
     odMLHomepage = HOMEPAGE
     registry = DocumentRegistry()
     editors = set()
-    welcome_disabled_actions = ["Save", "SaveAs", "NewSection", "NewProperty",
-                                "NewValue", "Delete", "CloneTab", "Validate",
-                                "odMLTablesCompare", "odMLTablesConvert",
+    welcome_disabled_actions = ["Save", "SaveAs", "Undo", "Redo", "NewSection",
+                                "NewProperty", "NewValue", "Delete", "CloneTab",
+                                "Validate", "odMLTablesCompare", "odMLTablesConvert",
                                 "odMLTablesFilter", "odMLTablesMerge"]
 
     def __init__(self, parent=None):

--- a/odmlui/EditorTab.py
+++ b/odmlui/EditorTab.py
@@ -70,12 +70,12 @@ class EditorTab(object):
                        "\n\nUse 'File .. import' to convert and open files of "
                        "a previous odML format.")
             ErrorDialog(self.window, err_header, err_msg)
+            self.window.set_welcome()
             return False
 
         except Exception as e:
             ErrorDialog(self.window, "Error parsing '%s'" % file_path, str(e))
-            if len(self.window.notebook) < 1:
-                self.window.welcome()
+            self.window.set_welcome()
             return False
 
         self.document.finalize()

--- a/odmlui/Wizard.py
+++ b/odmlui/Wizard.py
@@ -228,7 +228,14 @@ class DocumentWizard:
         return page.prepare(self, prev_page)
 
     def cancel(self, assistant):
+        self.cleanup()
         assistant.destroy()
+
+    def cleanup(self):
+        """
+        Placeholder to reset the main window view in case there is no open tab.
+        """
+        raise NotImplementedError
 
     def apply(self, assistant):
         """


### PR DESCRIPTION
The editor displays a welcome page and partially disabled icons when first opening. It should also display this page whenever there is no open tab.
In some specific cases e.g. when cancelling the document wizard or failing to load a document, the editor was not able to make sure, that icons were properly disabled and the welcome page displayed.

This PR 
- adds "Undo" and "Redo" to the icons that should not be active when no document is available.
- makes sure that the welcome page is also displayed when the wizard is cancelled or when a document could not be loaded and there is no open document.
- partially addresses #128.
