### PR TITLE
Edit Property Value fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ until the next release.
 
 # Latest changes in master
 
+## Edit terminology values fixes
+
+In some cases the values of terminology loaded Properties could not
+be edited anymore, since the required "pseudo_value" attribute was
+missing. Now every time a document is loaded or saved, all Properties
+are checked and modified in case the "pseudo_value" attribute is missing.
+
 
 # Version 1.4.1
 

--- a/odmlui/EditorTab.py
+++ b/odmlui/EditorTab.py
@@ -79,7 +79,12 @@ class EditorTab(object):
             return False
 
         self.document.finalize()
-        self.parse_properties(self.document.sections)
+
+        # Make sure all Properties within all sections are properly
+        # initialized with the "pseudo_values" attribute.
+        for sec in self.document.sections:
+            handle_section_import(sec)
+
         self.window.registry.add(self.document)
         self.window._info_bar.show_info("Loading of %s done!" % (os.path.basename(file_path)))
         return True

--- a/odmlui/EditorTab.py
+++ b/odmlui/EditorTab.py
@@ -51,11 +51,6 @@ class EditorTab(object):
         self.document = doc
         self.file_uri = None
 
-    def parse_properties(self, odml_sections):
-        for i in odml_sections:
-            create_pseudo_values(i.properties)
-            self.parse_properties(i.sections)
-
     def load(self, uri):
         self.file_uri = uri
         file_path = uri_to_path(uri)

--- a/odmlui/EditorTab.py
+++ b/odmlui/EditorTab.py
@@ -13,7 +13,7 @@ from odml.tools.version_converter import VersionConverter
 
 from .CommandManager import CommandManager
 from .Helpers import uri_to_path, get_parser_for_uri, get_extension, \
-    create_pseudo_values, get_parser_for_file_type
+    create_pseudo_values, get_parser_for_file_type, handle_section_import
 from .MessageDialog import ErrorDialog
 from .treemodel import event
 from .ValidationWindow import ValidationWindow
@@ -191,7 +191,15 @@ class EditorTab(object):
             self.window._info_bar.show_info("Save failed: %s" % e)
             return
 
-        self.document.finalize()  # undo the clean
+        # undo the clean
+        self.document.finalize()
+
+        # Finalize also removes all pseudo_values for any unchanged terminology
+        # entries, rendering these Properties unmodifiable. Re-initialize
+        # the pseudo_values for these Properties.
+        for sec in self.document.sections:
+            handle_section_import(sec)
+
         self.window._info_bar.show_info("%s was saved" % (os.path.basename(file_path)))
         self.edited = len(self.command_manager)
         return True  # TODO return false on any error and notify the user

--- a/odmlui/PropertyView.py
+++ b/odmlui/PropertyView.py
@@ -174,7 +174,6 @@ class PropertyView(TerminologyPopupTreeView):
             #  - Else, edit the property object
             if column_name == 'pseudo_values' and first_row:
                 prop = prop.pseudo_values[0]
-            if column_name == "pseudo_values" and first_row:
                 column_name = [column_name, "value"]  # backup the value attribute too
             cmd = commands.ChangeValue(
                     object=prop,

--- a/odmlui/PropertyView.py
+++ b/odmlui/PropertyView.py
@@ -173,8 +173,18 @@ class PropertyView(TerminologyPopupTreeView):
             #  - Only if the 'value' column is edited, edit the pseudo-value object.
             #  - Else, edit the property object
             if column_name == 'pseudo_values' and first_row:
-                prop = prop.pseudo_values[0]
                 column_name = [column_name, "value"]  # backup the value attribute too
+                # If the list of pseudovalues was empty, we need to initialize a new
+                # empty PseudoValue and add it properly to enable undo.
+                if not prop.pseudo_values:
+                    val = ValueModel.Value(prop)
+                    cmd = commands.AppendValue(obj=prop.pseudo_values,
+                                               attr=column_name,
+                                               val=val)
+                    self.execute(cmd)
+
+                prop = prop.pseudo_values[0]
+
             cmd = commands.ChangeValue(
                     object=prop,
                     attr=column_name,

--- a/odmlui/info.json
+++ b/odmlui/info.json
@@ -1,5 +1,5 @@
 {
-  "VERSION": "1.4.1",
+  "VERSION": "1.4.2",
   "AUTHOR": "Shubham Dighe, Hagen Fritsch, Christian Kellner, Jan Grewe, Achilleas Koutsou, Michael Sonntag",
   "COPYRIGHT": "(c) 2011-2018, German Neuroinformatics Node",
   "CONTACT": "dev@g-node.org",

--- a/odmlui/treemodel/TreeIters.py
+++ b/odmlui/treemodel/TreeIters.py
@@ -1,7 +1,7 @@
-import sys
 from . import GenericIter
 from . import nodes
 from .ValueModel import Value
+
 
 class PropIter(GenericIter.GenericIter):
     """
@@ -27,11 +27,11 @@ class PropIter(GenericIter.GenericIter):
     def get_mulitvalue(self, name):
         # Most of the stuff is empty and handled by the ValueIter
         if name == "pseudo_values":
-                return self.escape("<multi>")
+            return self.escape("<multi>")
         return ""
 
     def get_singlevalue(self, name):
-        #here we proxy the value object
+        # here we proxy the value object
         if not hasattr(self._obj, "pseudo_values") or len(self._obj.pseudo_values) == 0:
             return ""
 
@@ -51,6 +51,7 @@ class PropIter(GenericIter.GenericIter):
     @property
     def parent(self):
         return None
+
 
 class ValueIter(GenericIter.GenericIter):
     """
@@ -77,7 +78,7 @@ class ValueIter(GenericIter.GenericIter):
 
             return value
 
-        # Return an empty string for anything lese
+        # Return an empty string for anything else
         return ""
 
 
@@ -86,16 +87,18 @@ class SectionIter(GenericIter.GenericIter):
     def parent(self):
         if not self._obj.parent:
             return None
-        if not self._obj.parent.parent: # the parent is the document root
+        if not self._obj.parent.parent:  # the parent is the document root
             return None
         return super(SectionIter, self).parent
+
 
 class SectionPropertyIter(GenericIter.GenericIter):
     @property
     def n_children(self):
         return len(self._obj.properties)
 
+
 # associate the odml-classes to the corresponding iter-classes
-nodes.Section.IterClass  = SectionIter
+nodes.Section.IterClass = SectionIter
 nodes.Property.IterClass = PropIter
-Value.IterClass          = ValueIter
+Value.IterClass = ValueIter

--- a/odmlui/treemodel/TreeIters.py
+++ b/odmlui/treemodel/TreeIters.py
@@ -43,7 +43,10 @@ class PropIter(GenericIter.GenericIter):
 
     @property
     def n_children(self):
-        return len(self._obj.pseudo_values)
+        n_children = 0
+        if hasattr(self._obj, "pseudo_values"):
+            n_children = len(self._obj.pseudo_values)
+        return n_children
 
     @property
     def parent(self):

--- a/odmlui/treemodel/TreeIters.py
+++ b/odmlui/treemodel/TreeIters.py
@@ -32,7 +32,7 @@ class PropIter(GenericIter.GenericIter):
 
     def get_singlevalue(self, name):
         #here we proxy the value object
-        if len(self._obj.pseudo_values) == 0:
+        if not hasattr(self._obj, "pseudo_values") or len(self._obj.pseudo_values) == 0:
             return ""
 
         return ValueIter(self._obj.pseudo_values[0]).get_value(name)

--- a/odmlui/treemodel/TreeIters.py
+++ b/odmlui/treemodel/TreeIters.py
@@ -32,7 +32,7 @@ class PropIter(GenericIter.GenericIter):
 
     def get_singlevalue(self, name):
         # here we proxy the value object
-        if not hasattr(self._obj, "pseudo_values") or len(self._obj.pseudo_values) == 0:
+        if not hasattr(self._obj, "pseudo_values") or not self._obj.pseudo_values:
             return ""
 
         return ValueIter(self._obj.pseudo_values[0]).get_value(name)


### PR DESCRIPTION
This PR fixes #133.

Upon loading and saving all terminology based Properties without a value lost the odmlui specific `pseudo_values` attribute rendering them uneditable. This PR makes sure the `pseudo_values` attribute is added if needed and adds further corresponding checks to suppress any potential background errors.