### PR TITLE
Object removal and icon display fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ be edited anymore, since the required "pseudo_value" attribute was
 missing. Now every time a document is loaded or saved, all Properties
 are checked and modified in case the "pseudo_value" attribute is missing.
 
+## Fixes
+
+- Fixes background errors when deleting Properties or Document root Sections. See #99.
+- Fixes various occasions where the "Add Property" and "Add Value" icons were not 
+    properly deactivated. See #90.
+- The PropertyView is now properly reset when the last Section is removed from a
+    Document making sure there are no stale leftover Properties on display.
 
 # Version 1.4.1
 

--- a/odmlui/Editor.py
+++ b/odmlui/Editor.py
@@ -995,6 +995,12 @@ class EditorWindow(gtk.Window):
         if isinstance(obj, odmlui.treemodel.nodes.Property) and not parent.properties:
             self.on_object_select(parent)
 
+        # If we have removed a Section and it was the last Section of a Section
+        # (or a Document), select the parent to ensure proper selection and inactivation
+        # of icons.
+        if isinstance(obj, odmlui.treemodel.nodes.Section) and not parent.sections:
+            self.on_object_select(parent)
+
         return True
 
     # TODO should we save a navigation history here?

--- a/odmlui/Editor.py
+++ b/odmlui/Editor.py
@@ -663,6 +663,9 @@ class EditorWindow(gtk.Window):
         else:
             # Reset property treeview model in case of empty document
             self._property_tv.model = None
+            # Select document root in case of empty document to ensure
+            # root is selected and all Icons are in their proper activation state.
+            self.on_object_select(tab.document)
 
     @property
     def current_tab(self):

--- a/odmlui/Editor.py
+++ b/odmlui/Editor.py
@@ -987,6 +987,22 @@ class EditorWindow(gtk.Window):
 
         # Save the parent, after the obj is removed its too late
         parent = obj.parent
+
+        # In case of the last Section of a Document the PropertyView
+        # needs to be cleaned up before we can remove the Section itself.
+        # Otherwise the PropertyView will still contain stale Properties
+        # that are connected to nothing at all, wreaking havoc in the lands of odmlui.
+        # This slightly screws up the undo, but better than having a stale View...
+        if isinstance(obj, odmlui.treemodel.nodes.Section) and \
+                isinstance(parent, odmlui.treemodel.nodes.Document) and \
+                len(parent.sections) == 1:
+            # Something is screwed up with the iterator. When using a
+            # for loop, only every second property is removed; so we
+            # are using a while loop for now.
+            while len(obj.properties) > 0:
+                curr_prop = obj.properties[0]
+                widget.on_delete(None, curr_prop)
+
         widget.on_delete(None, obj)
 
         # If we have removed a property and it was the last property of a section,

--- a/odmlui/Editor.py
+++ b/odmlui/Editor.py
@@ -984,7 +984,17 @@ class EditorWindow(gtk.Window):
         obj = widget.get_selected_object()
         if obj is None:
             return False
+
+        # Save the parent, after the obj is removed its too late
+        parent = obj.parent
         widget.on_delete(None, obj)
+
+        # If we have removed a property and it was the last property of a section,
+        # select the parent section to ensure proper selection and inactivation
+        # of icons.
+        if isinstance(obj, odmlui.treemodel.nodes.Property) and not parent.properties:
+            self.on_object_select(parent)
+
         return True
 
     # TODO should we save a navigation history here?

--- a/odmlui/treemodel/TreeModel.py
+++ b/odmlui/treemodel/TreeModel.py
@@ -189,7 +189,11 @@ class TreeModel(gtk.GenericTreeModel):
         """
         self.row_deleted(old_path)
         iter = self.get_node_iter(parent)
-        if iter is not None:
+
+        # We need to check if the old path is already the very root.
+        # In this case we don't need to check any child toggles, since
+        # there are no toggleable children.
+        if iter is not None and len(old_path) > 1:
             path = self.get_path(iter)
             if path:
                 self.row_has_child_toggled(path, iter)


### PR DESCRIPTION
This PR 
- Fixes background errors when deleting Properties or Document root Sections. Closes #99.
- Fixes various occasions where the "Add Property" and "Add Value" icons were not 
    properly deactivated. Closes #90.
- The PropertyView is now properly reset when the last Section is removed from a
    Document making sure there are no stale leftover Properties on display.
