### PR TITLE
Text Editor bugfixes and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,16 @@ until the next release.
 
 # Latest changes in master
 
+## Features
+- The TextEditor for editing values of dtype `text` now features
+  'Save' and 'Cancel' buttons.
+
 ## Fixes
 - Fixes saving and loading of files using Windows.
+- Fixes a bug in `helpers.get_parser_for_file_type` 
+  where the file_type would default to `XML` by mistake.
+- Various TextEditor bug fixes. See #146
+
 
 # Version 1.4.2
 

--- a/odmlui/navigation_bar.py
+++ b/odmlui/navigation_bar.py
@@ -1,3 +1,10 @@
+"""
+'navigation_bar' contains the 'NavigationBar' class.
+
+This class provides functionality to browse from
+a currently selected model object to the document root.
+"""
+
 import pygtkcompat
 
 import gtk
@@ -7,6 +14,15 @@ pygtkcompat.enable_gtk(version='3.0')
 
 
 class NavigationBar(gtk.Label):
+    """
+    The NavigationBar widget provides an interactive
+    link list from the Document root of the currently
+    active Document to the object that is currently
+    selected in the data model of the main application window.
+
+    Activating any of the links selects the respective object
+    and updates the application window accordingly.
+    """
     def __init__(self, *args, **kargs):
         super(NavigationBar, self).__init__(*args, **kargs)
         self._document = None
@@ -23,6 +39,9 @@ class NavigationBar(gtk.Label):
 
     @property
     def document(self):
+        """
+        :return: The currently active document.
+        """
         return self._document
 
     @document.setter
@@ -36,16 +55,30 @@ class NavigationBar(gtk.Label):
 
     @property
     def current_object(self):
+        """
+        :return: The currently selected object.
+        """
         return self._current_object
 
     @current_object.setter
     def current_object(self, obj):
+        """
+        Update the internal selected object with provided *obj*
+        and update the view accordingly.
+        """
         self._current_object = obj
         self.update_display()
         self.on_selection_change(obj)
 
     def switch(self, _, path):
-        """called if a link in the property_status Label widget is clicked"""
+        """
+        Retrieve the object corresponding to a provided path and
+        make it the selected one, updating the view. If no path
+        was provided use the NavigationBar's document as a
+        fallback object to update the view.
+
+        Called if a link in the NavigationBar's Label widget is clicked.
+        """
         if path:
             path = [int(i) for i in path.split(":")]
             obj = self._document.from_path(path)
@@ -56,8 +89,8 @@ class NavigationBar(gtk.Label):
 
     def set_model(self, obj):
         """
-        show the hierarchy for object *obj* and make
-        it the selected one
+        Show the hierarchy for object *obj* and make it
+        the selected one, updating the view.
         """
         self._current_hierarchy = [obj]
 
@@ -69,6 +102,11 @@ class NavigationBar(gtk.Label):
         self.current_object = cur
 
     def update_display(self):
+        """
+        Update the NavigationBar's label text with a
+        list of object links from the Document root
+        to the currently selected object.
+        """
         names = []
         cur = self._current_object
         for obj in self._current_hierarchy:
@@ -87,16 +125,18 @@ class NavigationBar(gtk.Label):
 
     def on_selection_change(self, obj):
         """
-        called whenever this widget elects a new current obj
+        Called whenever a new object *obj* in the underlying
+        data model is selected.
+
+        The actual method is set on the class at the point of usage.
         """
-        raise NotImplementedError
+        pass
 
     def on_section_changed(self, context):
         """
-        this is called by the Eventable modified MixIns of Value/Property/Section
-        and causes the GUI to refresh correspondingly
+        Refresh the NavigationBar display after the content
+        of the currently displayed document has been changed.
         """
-        # we are only interested in changes on sections
         if context.cur is not self._document:
             return
 

--- a/odmlui/text_editor.py
+++ b/odmlui/text_editor.py
@@ -22,8 +22,8 @@ class TextEditor(gtk.Window):
             attr = "pseudo_values"
 
         self.attr = attr
-        self.set_title("Editing %s.%s" % (repr(obj), attr))
-        self.set_default_size(400, 600)
+        self.set_title("Editing %s. Closing window saves changes" % repr(obj))
+        self.set_default_size(600, 600)
         self.connect('destroy', self.on_close)
 
         self.text = gtk.TextView()

--- a/odmlui/text_editor.py
+++ b/odmlui/text_editor.py
@@ -2,6 +2,7 @@ import pygtkcompat
 
 import gtk
 
+from .commands import ChangeValue
 from .scrolled_window import ScrolledWindow
 
 pygtkcompat.enable()
@@ -18,19 +19,15 @@ class TextEditor(gtk.Window):
         self.connect('destroy', self.on_close)
 
         self.text = gtk.TextView()
-        buffer = self.text.get_buffer()
-        buffer.set_text(getattr(obj, attr))
+        text_buffer = self.text.get_buffer()
+        text_buffer.set_text(getattr(obj, attr))
 
         self.add(ScrolledWindow(self.text))
         self.show_all()
 
-    def on_close(self, window):
-        from . import commands
-        buffer = self.text.get_buffer()
-        start, end = buffer.get_bounds()
-        text = buffer.get_text(start, end)
-        cmd = commands.ChangeValue(object=self.obj, attr=self.attr, new_value=text)
-        self.execute(cmd)
-
-    def execute(self, cmd):
+    def on_close(self, _):
+        text_buffer = self.text.get_buffer()
+        start, end = text_buffer.get_bounds()
+        text = text_buffer.get_text(start, end)
+        cmd = ChangeValue(object=self.obj, attr=self.attr, new_value=text)
         cmd()

--- a/odmlui/text_editor.py
+++ b/odmlui/text_editor.py
@@ -28,6 +28,7 @@ class TextEditor(gtk.Window):
     def on_close(self, _):
         text_buffer = self.text.get_buffer()
         start, end = text_buffer.get_bounds()
-        text = text_buffer.get_text(start, end)
+        include_hidden_text = False
+        text = text_buffer.get_text(start, end, include_hidden_text)
         cmd = ChangeValue(object=self.obj, attr=self.attr, new_value=text)
         cmd()

--- a/odmlui/text_editor.py
+++ b/odmlui/text_editor.py
@@ -55,3 +55,24 @@ class TextEditor(gtk.Window):
         text = text_buffer.get_text(start, end, include_hidden_text)
         cmd = ChangeValue(object=self.obj, attr=self.attr, new_value=text)
         cmd()
+
+    def on_cancel(self, _):
+        """
+        Close widget w/o doing anything
+        """
+        self.destroy()
+
+    def on_ok(self, _):
+        """
+        Reads the text buffer value, and updates
+        the target object with the new value via
+        a command.ChangeValue object.
+        """
+        text_buffer = self.text.get_buffer()
+        start, end = text_buffer.get_bounds()
+        include_hidden_text = False
+        text = text_buffer.get_text(start, end, include_hidden_text)
+        cmd = ChangeValue(object=self.obj, attr=self.attr, new_value=text)
+        cmd()
+
+        self.destroy()

--- a/odmlui/text_editor.py
+++ b/odmlui/text_editor.py
@@ -34,21 +34,3 @@ class TextEditor(gtk.Window):
 
     def execute(self, cmd):
         cmd()
-
-
-if __name__ == "__main__":
-    class StandAloneTextEditor(object):
-        _prop_a = "no text"
-
-        @property
-        def prop_a(self):
-            print("read prop a")
-            return self._prop_a
-
-        @prop_a.setter
-        def prop_a(self, new_value):
-            print("set a to ", repr(new_value))
-            self._prop_a = new_value
-
-    _ = TextEditor(StandAloneTextEditor(), "prop_a")
-    gtk.mainloop()

--- a/odmlui/text_editor.py
+++ b/odmlui/text_editor.py
@@ -13,6 +13,13 @@ class TextEditor(gtk.Window):
     def __init__(self, obj, attr):
         super(TextEditor, self).__init__()
         self.obj = obj
+
+        # The 'value' attribute of the Values Class
+        # can only be set via the 'pseudo_values' attribute.
+        # We need to account for this particularity.
+        if attr == "value":
+            attr = "pseudo_values"
+
         self.attr = attr
         self.set_title("Editing %s.%s" % (repr(obj), attr))
         self.set_default_size(400, 600)

--- a/odmlui/text_editor.py
+++ b/odmlui/text_editor.py
@@ -4,6 +4,7 @@ import gtk
 
 from .commands import ChangeValue
 from .scrolled_window import ScrolledWindow
+from .treemodel.value_model import Value
 
 pygtkcompat.enable()
 pygtkcompat.enable_gtk(version='3.0')
@@ -17,7 +18,7 @@ class TextEditor(gtk.Window):
         # The 'value' attribute of the Values Class
         # can only be set via the 'pseudo_values' attribute.
         # We need to account for this particularity.
-        if attr == "value":
+        if isinstance(obj, Value) and attr == "value":
             attr = "pseudo_values"
 
         self.attr = attr

--- a/odmlui/text_editor.py
+++ b/odmlui/text_editor.py
@@ -1,3 +1,7 @@
+"""
+'text_editor' provides a simple TextEditor Window class.
+"""
+
 import pygtkcompat
 
 import gtk
@@ -11,6 +15,12 @@ pygtkcompat.enable_gtk(version='3.0')
 
 
 class TextEditor(gtk.Window):
+    """
+    TextEditor is a simple text editor window that
+    reads the value of a passed objects attribute
+    and overwrites this attributes value with the content
+    of the editor when the window is closed.
+    """
     def __init__(self, obj, attr):
         super(TextEditor, self).__init__()
         self.obj = obj
@@ -34,6 +44,11 @@ class TextEditor(gtk.Window):
         self.show_all()
 
     def on_close(self, _):
+        """
+        Reads the text buffer value, and updates
+        the target object with the new value via
+        a command.ChangeValue object.
+        """
         text_buffer = self.text.get_buffer()
         start, end = text_buffer.get_bounds()
         include_hidden_text = False

--- a/odmlui/text_editor.py
+++ b/odmlui/text_editor.py
@@ -32,29 +32,39 @@ class TextEditor(gtk.Window):
             attr = "pseudo_values"
 
         self.attr = attr
-        self.set_title("Editing %s. Closing window saves changes" % repr(obj))
+        self.set_title("Editing %s" % repr(obj))
         self.set_default_size(600, 600)
-        self.connect('destroy', self.on_close)
 
+        # Text container
         self.text = gtk.TextView()
         text_buffer = self.text.get_buffer()
         text_buffer.set_text(getattr(obj, attr))
+        text_container = ScrolledWindow(self.text)
 
-        self.add(ScrolledWindow(self.text))
+        # Main window container. Using the recommended gtk.Box with
+        # gtk.ORIENTATION_VERTICAL fails so we stick
+        # to the deprecated VBox for now.
+        vbox = gtk.VBox()
+        vbox.pack_start(text_container)
+
+        # Button Container
+        hbox = gtk.Box(gtk.ORIENTATION_HORIZONTAL)
+        save = gtk.Button("Save")
+        save.connect('clicked', self.on_ok)
+        hbox.add(save)
+
+        cancel = gtk.Button("Cancel")
+        cancel.connect('clicked', self.on_cancel)
+        hbox.add(cancel)
+
+        h_align = gtk.Alignment(1, 0, 0, 0)
+        h_align.add(hbox)
+
+        vbox.pack_start(h_align, False, False)
+
+        self.add(vbox)
+
         self.show_all()
-
-    def on_close(self, _):
-        """
-        Reads the text buffer value, and updates
-        the target object with the new value via
-        a command.ChangeValue object.
-        """
-        text_buffer = self.text.get_buffer()
-        start, end = text_buffer.get_bounds()
-        include_hidden_text = False
-        text = text_buffer.get_text(start, end, include_hidden_text)
-        cmd = ChangeValue(object=self.obj, attr=self.attr, new_value=text)
-        cmd()
 
     def on_cancel(self, _):
         """

--- a/odmlui/treemodel/value_model.py
+++ b/odmlui/treemodel/value_model.py
@@ -58,7 +58,7 @@ class Value(BaseObject, ValueNode, event.ModificationNotifier):
         self._index = index
 
     def __repr__(self):
-        return "PseudoValue <%s>" % str(self.pseudo_values)
+        return "PseudoValue <%s>" % self.get_display()
 
     def __eq__(self, obj):
         """

--- a/odmlui/treemodel/value_model.py
+++ b/odmlui/treemodel/value_model.py
@@ -135,7 +135,7 @@ class Value(BaseObject, ValueNode, event.ModificationNotifier):
         """
         return a textual representation that can be used for display
 
-        typically takes the first line (max *max_length* chars) and adds '…'
+        typically takes the first line (max *max_length* chars) and adds '[...]'
         """
         text = str(self.pseudo_values)
 
@@ -148,8 +148,9 @@ class Value(BaseObject, ValueNode, event.ModificationNotifier):
         text = text.split("\n")[0]
         if max_length != -1:
             text = text[:max_length]
+
         if self.can_display(text, max_length):
-            return (text + u'…').encode('utf-8')
+            return "%s [...]" % text
 
         return "(%d bytes)" % len(self._value)
 

--- a/test/test_navigation_bar.py
+++ b/test/test_navigation_bar.py
@@ -85,6 +85,28 @@ class TestNavigationBar(unittest.TestCase):
                  "<a href=\"0:1:0\"><b>prop</b></a> "
         self.assertEqual(self.nav_bar.get_label(), wanted)
 
+    def test_set_model(self):
+        self.assertIsNone(self.nav_bar.current_object)
+        self.assertEqual(self.nav_bar.get_label(), "")
+
+        doc = self.create_ui_doc()
+        self.nav_bar.set_model(doc)
+
+        self.assertEqual(doc, self.nav_bar.current_object)
+        self.assertEqual([doc], self.nav_bar._current_hierarchy)
+        self.assertEqual(self.nav_bar.get_label(),
+                         "Attributes | <a href=\"\"><b>Document</b></a> ")
+
+        sec = doc.sections[0]
+        prop = doc.sections[0].properties[0]
+        self.nav_bar.set_model(prop)
+        self.assertEqual(prop, self.nav_bar.current_object)
+        self.assertEqual([prop, sec, doc], self.nav_bar._current_hierarchy)
+        wanted = "Attributes | <a href=\"\">Document</a>: " + \
+                 "<a href=\"0\">sec</a>: " + \
+                 "<a href=\"0:1:0\"><b>prop</b></a> "
+        self.assertEqual(self.nav_bar.get_label(), wanted)
+
     def test_document(self):
         self.assertIsNone(self.nav_bar.document)
 

--- a/test/test_navigation_bar.py
+++ b/test/test_navigation_bar.py
@@ -24,6 +24,45 @@ class TestNavigationBar(unittest.TestCase):
         self.assertIsNone(self.nav_bar._current_object)
         self.assertEqual([], self.nav_bar._current_hierarchy)
 
+    def test_document(self):
+        self.assertIsNone(self.nav_bar.document)
+
+        doc = self.create_ui_doc("Author")
+
+        # make sure the change handler is empty
+        self.assertIsInstance(doc, odmlui.treemodel.nodes.Document)
+        self.assertIsNone(doc._change_handler)
+
+        self.nav_bar.document = doc
+
+        # check that the document has been set on the nav_bar
+        self.assertEqual(doc, self.nav_bar.document)
+
+        # make sure the proper nav_bar method has been set
+        # on the documents change handler
+        self.assertEqual(1, len(doc._change_handler))
+        self.assertEqual(doc._change_handler.handlers[0], self.nav_bar.on_section_changed)
+
+        # test that the document root is selected
+        self.assertEqual(1, len(self.nav_bar._current_hierarchy))
+        self.assertEqual(doc, self.nav_bar._current_hierarchy[0])
+        self.assertEqual(doc, self.nav_bar._current_object)
+
+        # test label text
+        self.assertEqual(self.nav_bar.get_label(),
+                         "Attributes | <a href=\"\"><b>Document</b></a> ")
+
+        # test reset with a different document
+        other_doc = self.create_ui_doc("Other author")
+        self.nav_bar.document = other_doc
+
+        self.assertNotEqual(doc, self.nav_bar.document)
+        self.assertNotEqual(doc, self.nav_bar._current_hierarchy[0])
+        self.assertNotEqual(doc, self.nav_bar._current_object)
+        self.assertEqual(other_doc, self.nav_bar.document)
+        self.assertEqual(other_doc, self.nav_bar._current_hierarchy[0])
+        self.assertEqual(other_doc, self.nav_bar._current_object)
+
     @staticmethod
     def create_ui_doc(author=""):
         doc = odml.Document(author=author)

--- a/test/test_navigation_bar.py
+++ b/test/test_navigation_bar.py
@@ -1,0 +1,14 @@
+"""
+Tests for odmlui.navigation_bar class.
+"""
+
+import unittest
+
+from odmlui.navigation_bar import NavigationBar
+
+
+class TestNavigationBar(unittest.TestCase):
+
+    def setUp(self):
+        self.nav_bar = NavigationBar()
+

--- a/test/test_navigation_bar.py
+++ b/test/test_navigation_bar.py
@@ -58,6 +58,33 @@ class TestNavigationBar(unittest.TestCase):
 
         self.assertEqual(self.nav_bar.get_label(), wanted)
 
+    def test_current_object(self):
+        self.assertIsNone(self.nav_bar.current_object)
+        self.assertEqual(self.nav_bar.get_label(), "")
+
+        doc = self.create_ui_doc()
+
+        # the current_object setter ignores the '_current_hierarchy'
+        # attribute, we need to deal with this manually.
+        self.nav_bar._current_hierarchy = [doc]
+
+        self.nav_bar.current_object = doc
+        self.assertEqual(doc, self.nav_bar.current_object)
+        self.assertEqual(self.nav_bar.get_label(),
+                         "Attributes | <a href=\"\"><b>Document</b></a> ")
+
+        sec = doc.sections[0]
+        prop = doc.sections[0].properties[0]
+        self.nav_bar._current_hierarchy = [prop, sec, doc]
+
+        self.nav_bar.current_object = prop
+        self.assertEqual(prop, self.nav_bar.current_object)
+
+        wanted = "Attributes | <a href=\"\">Document</a>: " + \
+                 "<a href=\"0\">sec</a>: " + \
+                 "<a href=\"0:1:0\"><b>prop</b></a> "
+        self.assertEqual(self.nav_bar.get_label(), wanted)
+
     def test_document(self):
         self.assertIsNone(self.nav_bar.document)
 

--- a/test/test_navigation_bar.py
+++ b/test/test_navigation_bar.py
@@ -4,6 +4,13 @@ Tests for odmlui.navigation_bar class.
 
 import unittest
 
+import odml
+
+# Import is required to use the event capable odmlui implementation
+# of odml entities (Document, Section, Property).
+import odmlui.treemodel.mixin
+
+from odmlui.helpers import handle_section_import
 from odmlui.navigation_bar import NavigationBar
 
 
@@ -17,3 +24,13 @@ class TestNavigationBar(unittest.TestCase):
         self.assertIsNone(self.nav_bar._current_object)
         self.assertEqual([], self.nav_bar._current_hierarchy)
 
+    @staticmethod
+    def create_ui_doc(author=""):
+        doc = odml.Document(author=author)
+        sec = odml.Section(name="sec", parent=doc)
+        _ = odml.Property(name="prop", parent=sec)
+
+        for sec in doc.sections:
+            handle_section_import(sec)
+
+        return doc

--- a/test/test_navigation_bar.py
+++ b/test/test_navigation_bar.py
@@ -12,3 +12,8 @@ class TestNavigationBar(unittest.TestCase):
     def setUp(self):
         self.nav_bar = NavigationBar()
 
+    def test_init(self):
+        self.assertIsNone(self.nav_bar._document)
+        self.assertIsNone(self.nav_bar._current_object)
+        self.assertEqual([], self.nav_bar._current_hierarchy)
+

--- a/test/test_navigation_bar.py
+++ b/test/test_navigation_bar.py
@@ -146,6 +146,24 @@ class TestNavigationBar(unittest.TestCase):
         self.assertEqual(other_doc, self.nav_bar._current_hierarchy[0])
         self.assertEqual(other_doc, self.nav_bar._current_object)
 
+    def test_switch(self):
+        doc = self.create_ui_doc()
+        self.nav_bar.document = doc
+
+        self.assertEqual(self.nav_bar.current_object, doc)
+
+        prop = doc.sections[0].properties[0]
+
+        self.nav_bar.emit("activate-link", "0:1:0")
+        self.assertEqual(self.nav_bar.current_object, prop)
+
+        sec = doc.sections[0]
+        self.nav_bar.emit("activate-link", "0")
+        self.assertEqual(self.nav_bar.current_object, sec)
+
+        self.nav_bar.emit("activate-link", "")
+        self.assertEqual(self.nav_bar.current_object, doc)
+
     @staticmethod
     def create_ui_doc(author=""):
         doc = odml.Document(author=author)

--- a/test/test_navigation_bar.py
+++ b/test/test_navigation_bar.py
@@ -17,12 +17,46 @@ from odmlui.navigation_bar import NavigationBar
 class TestNavigationBar(unittest.TestCase):
 
     def setUp(self):
+        self.nav_bar = None
         self.nav_bar = NavigationBar()
 
     def test_init(self):
         self.assertIsNone(self.nav_bar._document)
         self.assertIsNone(self.nav_bar._current_object)
         self.assertEqual([], self.nav_bar._current_hierarchy)
+
+    def test_update_display(self):
+        self.assertEqual("", self.nav_bar.get_label())
+
+        self.nav_bar.update_display()
+        self.assertEqual("Attributes |  ", self.nav_bar.get_label())
+
+        # manually set selected objects and object hierarchy
+        # to simulate test case.
+        doc = self.create_ui_doc()
+
+        # test document root selected
+        self.nav_bar._current_object = doc
+        self.nav_bar._current_hierarchy = [doc]
+        self.assertEqual("Attributes |  ", self.nav_bar.get_label())
+
+        self.nav_bar.update_display()
+        self.assertEqual(self.nav_bar.get_label(),
+                         "Attributes | <a href=\"\"><b>Document</b></a> ")
+
+        # test property selected
+        sec = doc.sections[0]
+        prop = doc.sections[0].properties[0]
+        self.nav_bar._current_object = prop
+        self.nav_bar._current_hierarchy = [prop, sec, doc]
+
+        self.nav_bar.update_display()
+
+        wanted = "Attributes | <a href=\"\">Document</a>: " + \
+                 "<a href=\"0\">sec</a>: " + \
+                 "<a href=\"0:1:0\"><b>prop</b></a> "
+
+        self.assertEqual(self.nav_bar.get_label(), wanted)
 
     def test_document(self):
         self.assertIsNone(self.nav_bar.document)


### PR DESCRIPTION
This PR unbreaks the TextEditor (required to edit large odml values of dtype `text`).
- Fixes an exception by using the appropriate number of required method arguments when reading
text from the editor before saving. Fixes #148.
- Uses the proper `pseudo_values` setter when setting the new value from the TextEditor.
- Hotfixes a display error of a hardcoded UTF-8 character in pseudo values on longer dtype `text` values.
- Updates the TextEditor window to include a `save` and a `cancel` button. Closes #155.
- Adds multiple tests for the NavigationBar.
