### PR TITLE
PropertyView bugfixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,6 @@ matrix:
       language: generic
       env: OSXENV=3.5 CONDA=Y CONDAPY=3.5
 
-  include:
-    - os: linux
-      python: "2.7_with_system_site_packages"
-      sudo: required
-      env: CONDA=N
-
     - os: linux
       python: "2.7"
       sudo: required
@@ -41,6 +35,12 @@ matrix:
       env:
         - CONDA=Y
         - CONDAPY=3.5
+
+  include:
+    - os: linux
+      python: "2.7_with_system_site_packages"
+      sudo: required
+      env: CONDA=N
 
 #    Keep only one osx branch active for now
 #    since currently osx builds on travis

--- a/odmlui/editor.py
+++ b/odmlui/editor.py
@@ -1091,7 +1091,11 @@ class EditorWindow(gtk.Window):
     @gui_action("Undo", tooltip="Undo last editing action", stock_id=gtk.STOCK_UNDO,
                 label="_Undo", accelerator="<control>Z")
     def undo(self, action):
-        self.current_tab.command_manager.undo()
+        try:
+            self.current_tab.command_manager.undo()
+        except Exception as exc:
+            self._info_bar.show_info("Unable to undo last action")
+            print("Encountered and exception during undo: %s:%s" % (type(exc), exc))
 
         # Reset model and view in case a value has been tampered with
         # to avoid Model and View being out of sync.

--- a/odmlui/editor.py
+++ b/odmlui/editor.py
@@ -1095,7 +1095,7 @@ class EditorWindow(gtk.Window):
             self.current_tab.command_manager.undo()
         except Exception as exc:
             self._info_bar.show_info("Unable to undo last action")
-            print("Encountered and exception during undo: %s:%s" % (type(exc), exc))
+            print("Encountered an exception during undo: %s:%s" % (type(exc), exc))
 
         # Reset model and view in case a value has been tampered with
         # to avoid Model and View being out of sync.

--- a/odmlui/property_view.py
+++ b/odmlui/property_view.py
@@ -126,17 +126,26 @@ class PropertyView(TerminologyPopupTreeView):
         """called when a different property is selected"""
         pass
 
-    def on_get_tooltip(self, model, _, tree_iter, tooltip):
+    @staticmethod
+    def on_get_tooltip(model, tree_iter, tooltip):
         """
-        set the tooltip text, if the gui queries for it
+        If the GUI is queried for a tooltip on a Property,
+        set any existing validation errors as tooltip text.
+
+        This method is currently inactivated in TreeView.init
+        until the pseudo_value display can be resolved.
+
+        :return: True if the tooltip text is set, False otherwise
         """
         obj = model.get_object(tree_iter)
         doc = obj.document
         if doc and hasattr(doc, "validation_result"):
             errors = doc.validation_result[obj]
-            if len(errors) > 0:
+            if errors:
                 tooltip.set_text("\n".join([e.msg for e in errors]))
                 return True
+
+        return False
 
     def on_object_edit(self, tree_iter, column_name, new_text):
         """

--- a/odmlui/property_view.py
+++ b/odmlui/property_view.py
@@ -218,8 +218,8 @@ class PropertyView(TerminologyPopupTreeView):
             prop = obj
 
             # we care about the properties only
-            if hasattr(obj, "_property"):
-                prop = obj._property
+            if isinstance(obj, value_model.Value):
+                prop = obj.parent
 
             for item in self.create_popup_menu_items("Add Value", "Empty Value", prop,
                                                      self.add_value, self._value_filter,

--- a/odmlui/property_view.py
+++ b/odmlui/property_view.py
@@ -53,10 +53,9 @@ class PropertyView(TerminologyPopupTreeView):
 
         # set up our drag provider
         drager = DragProvider(self._treeview)
-        _exec = lambda cmd: self.execute(cmd)
-        v_drop = ValueDrop(exec_func=_exec)
-        p_drop = PropertyDrop(exec_func=_exec)
-        s_drop = SectionDrop(exec_func=_exec)
+        v_drop = ValueDrop(exec_func=self.execute)
+        p_drop = PropertyDrop(exec_func=self.execute)
+        s_drop = SectionDrop(exec_func=self.execute)
         for target in [
                 OdmlDrag(mime="odml/property-ref", inst=BaseProperty),
                 TextDrag(mime="odml/property", inst=BaseProperty),
@@ -64,18 +63,18 @@ class PropertyView(TerminologyPopupTreeView):
                 TextDrag(mime="odml/value", inst=value_model.Value),
                 TextDrag(mime="TEXT"),
                 OdmlDrop(mime="odml/value-ref", target=v_drop,
-                         registry=registry, exec_func=_exec),
+                         registry=registry, exec_func=self.execute),
                 OdmlDrop(mime="odml/property-ref", target=p_drop,
-                         registry=registry, exec_func=_exec),
+                         registry=registry, exec_func=self.execute),
                 OdmlDrop(mime="odml/section-ref", target=s_drop,
-                         registry=registry, exec_func=_exec),
+                         registry=registry, exec_func=self.execute),
                 TextDrop(mime="odml/value", target=v_drop),
                 TextDrop(mime="odml/property", target=p_drop),
                 TextDrop(mime="odml/section", target=s_drop),
-                TextGenericDropForPropertyTV(exec_func=_exec), ]:
+                TextGenericDropForPropertyTV(exec_func=self.execute), ]:
 
             drager.append(target)
-        drager.execute = _exec
+        drager.execute = self.execute
         drager.connect()
 
     @staticmethod

--- a/odmlui/property_view.py
+++ b/odmlui/property_view.py
@@ -294,26 +294,23 @@ class PropertyView(TerminologyPopupTreeView):
 
     def add_value(self, _, obj_value_pair):
         """
-        popup menu action: add value
+        Add a value to a selected Property
 
-        add a value to the selected property
+        :param obj_value_pair: obj ... property, val ... string containing added value
         """
         (obj, val) = obj_value_pair
-        if val is None:
-            val = value_model.Value(obj)
-        else:
-            val = val.clone()
+        new_val = value_model.Value(obj)
 
-        cmd = commands.AppendValue(obj=obj.pseudo_values, val=val)
+        # Add new empty PseudoValue to the Properties PseudoValue list
+        cmd = commands.AppendValue(obj=obj.pseudo_values, val=new_val)
         self.execute(cmd)
 
-        # Reset model if the Value changes from "normal" to MultiValue.
-        if self.model and len(obj.values) > 1:
-            self.model.destroy()
-            self.model = property_model.PropertyModel(obj.parent)
+        # Update the empty new PseudoValue with the actual value.
+        if val:
+            new_val.pseudo_values = val
 
-        # Reselect updated object to update view.
-        self.select_object(obj)
+        # Reset the view to make sure the changes are properly displayed.
+        self.reset_value_view(None)
 
     def add_property(self, _, obj_prop_pair):
         """

--- a/odmlui/property_view.py
+++ b/odmlui/property_view.py
@@ -23,9 +23,6 @@ from .dnd.text import TextDrag, TextDrop, TextGenericDropForPropertyTV
 pygtkcompat.enable()
 pygtkcompat.enable_gtk(version='3.0')
 
-COL_KEY = 0
-COL_VALUE = 1
-
 
 class PropertyView(TerminologyPopupTreeView):
     """

--- a/odmlui/property_view.py
+++ b/odmlui/property_view.py
@@ -266,6 +266,7 @@ class PropertyView(TerminologyPopupTreeView):
         popup menu action: reset property
         """
         dst = prop.get_merged_equivalent().clone()
+        create_pseudo_values([dst])
         cmd = commands.ReplaceObject(obj=prop, repl=dst)
         self.execute(cmd)
 

--- a/odmlui/property_view.py
+++ b/odmlui/property_view.py
@@ -78,7 +78,8 @@ class PropertyView(TerminologyPopupTreeView):
         drager.execute = _exec
         drager.connect()
 
-    def dtype_renderer_function(self, _, cell_combobox, tree_model, tree_iter, data):
+    @staticmethod
+    def dtype_renderer(_, cell_combobox, tree_model, tree_iter, data):
         """
             Defines a custom cell renderer function, which is executed for
             every cell of the column, and sets the DType value from the underlying model.
@@ -371,6 +372,6 @@ class PropertyView(TerminologyPopupTreeView):
         combo_col = gtk.TreeViewColumn(name, combo_renderer)
         combo_col.set_min_width(40)
         combo_col.set_resizable(True)
-        combo_col.set_cell_data_func(combo_renderer, self.dtype_renderer_function, col_id)
+        combo_col.set_cell_data_func(combo_renderer, self.dtype_renderer, col_id)
 
         return combo_col

--- a/odmlui/property_view.py
+++ b/odmlui/property_view.py
@@ -223,13 +223,13 @@ class PropertyView(TerminologyPopupTreeView):
 
             for item in self.create_popup_menu_items("Add Value", "Empty Value", prop,
                                                      self.add_value, self._value_filter,
-                                                     lambda val: val.values,
+                                                     lambda curr_val: curr_val,
                                                      stock="odml-add-Value"):
                 menu_items.append(item)
 
             for item in self.create_popup_menu_items("Set Value", "Empty Value", prop,
                                                      self.set_value, self._value_filter,
-                                                     lambda val: val.values):
+                                                     lambda curr_val: curr_val):
                 if item.get_submenu() is None:
                     continue  # don't want a sole Set Value item
                 menu_items.append(item)

--- a/odmlui/property_view.py
+++ b/odmlui/property_view.py
@@ -411,7 +411,7 @@ class PropertyView(TerminologyPopupTreeView):
         Reset the view if the value model has changed e.g. after an undo or a redo.
         """
         obj = self.get_selected_object()
-        if obj is None or (not hasattr(obj, "parent") and obj.parent):
+        if obj is None or not hasattr(obj, "parent") or not obj.parent:
             return
 
         prop = obj

--- a/odmlui/property_view.py
+++ b/odmlui/property_view.py
@@ -6,8 +6,6 @@ import odml.dtypes as dtypes
 from odml import DType
 from odml.property import BaseProperty
 
-from odmlui.treemodel.nodes import Property as TreeModelProperty
-
 import gtk
 
 from . import commands

--- a/odmlui/property_view.py
+++ b/odmlui/property_view.py
@@ -166,8 +166,6 @@ class PropertyView(TerminologyPopupTreeView):
                 new_text == "<multi>":
             return
 
-        cmd = None
-
         # if we edit another attribute (e.g. unit), set this
         # for all values of this property.
         if first_row_of_multi and column_name == "pseudo_values":
@@ -198,12 +196,18 @@ class PropertyView(TerminologyPopupTreeView):
 
                 prop = prop.pseudo_values[0]
 
-            cmd = commands.ChangeValue(object=prop,
-                                       attr=column_name,
-                                       new_value=new_text)
+            cmd = commands.ChangeValue(object=prop, attr=column_name, new_value=new_text)
 
         if cmd:
             self.execute(cmd)
+
+    @staticmethod
+    def _value_filter(prop):
+        values = []
+        for val in prop.values:
+            if val is not None and val != "":
+                values.append(val)
+        return values
 
     def get_popup_menu_items(self):
         model, _, obj = self.popup_data
@@ -220,16 +224,14 @@ class PropertyView(TerminologyPopupTreeView):
             if hasattr(obj, "_property"):
                 prop = obj._property
 
-            value_filter = lambda prop: [val for val in
-                                         prop.values if val.values is not None and
-                                         val.values != ""]
             for item in self.create_popup_menu_items("Add Value", "Empty Value", prop,
-                                                     self.add_value, value_filter,
+                                                     self.add_value, self._value_filter,
                                                      lambda val: val.values,
                                                      stock="odml-add-Value"):
                 menu_items.append(item)
+
             for item in self.create_popup_menu_items("Set Value", "Empty Value", prop,
-                                                     self.set_value, value_filter,
+                                                     self.set_value, self._value_filter,
                                                      lambda val: val.values):
                 if item.get_submenu() is None:
                     continue  # don't want a sole Set Value item

--- a/odmlui/property_view.py
+++ b/odmlui/property_view.py
@@ -335,6 +335,7 @@ class PropertyView(TerminologyPopupTreeView):
             name = self.get_new_obj_name(obj.properties, prefix=prefix)
             prop = prop.clone()
             prop.name = name
+            create_pseudo_values([prop])
 
         cmd = commands.AppendValue(obj=obj, val=prop)
         self.execute(cmd)

--- a/odmlui/section_view.py
+++ b/odmlui/section_view.py
@@ -139,11 +139,19 @@ class SectionView(TerminologyPopupTreeView):
         """
         pass
 
-    def on_get_tooltip(self, model, path, iter, tooltip):
+    @staticmethod
+    def on_get_tooltip(model, tree_iter, tooltip):
         """
-        set the tooltip text, if the gui queries for it
+        If the GUI is queried for a tooltip on a Section,
+        set the objects name and any existing validation errors
+        as tooltip text.
+
+        This method is currently inactivated in TreeView.init
+        until the pseudo_value display can be resolved.
+
+        :return: Always returns True
         """
-        obj = model.get_object(iter)
+        obj = model.get_object(tree_iter)
 
         merged = obj.get_merged_equivalent()
         info = []
@@ -171,4 +179,5 @@ class SectionView(TerminologyPopupTreeView):
                 error = "\n\nErrors:\n" + "\n".join([e.msg for e in errors])
 
         tooltip.set_text(text + error)
+
         return True

--- a/odmlui/tree_view.py
+++ b/odmlui/tree_view.py
@@ -31,8 +31,8 @@ class TreeView(object):
         # and also, it messes up with the display of properties in the "Property
         # View". Hence, disabling this temporarily.
         # if self.on_get_tooltip is not None:
-        #     tv.connect('query-tooltip', self.on_query_tooltip)
-        #     tv.props.has_tooltip = True
+        #    curr_view.connect('query-tooltip', self.on_query_tooltip)
+        #    curr_view.props.has_tooltip = True
 
         curr_view.set_headers_visible(True)
         curr_view.set_rules_hint(True)
@@ -114,7 +114,7 @@ class TreeView(object):
             if model is None:
                 return
             value = model.get(iter, 0)
-            if self.on_get_tooltip(model, path, iter, tooltip) is not None:
+            if self.on_get_tooltip(model, iter, tooltip):
                 widget.set_tooltip_row(tooltip, path)
                 return True
         return False

--- a/odmlui/treemodel/value_model.py
+++ b/odmlui/treemodel/value_model.py
@@ -79,6 +79,10 @@ class Value(BaseObject, ValueNode, event.ModificationNotifier):
         return True
 
     @property
+    def index(self):
+        return self._index
+
+    @property
     def parent(self):
         """the property containing this value"""
         return self._property


### PR DESCRIPTION
This PR fixes a bunch of bugs in the PropertyView:
- Fixes that when adding a Terminology Property via the context menu in the PropertyView, the added Property was not initialized with pseudo_values, leaving these Properties broken with respect to adding actual values to them. Closes #161.
- Fixes that when using the popup menu to reset a Terminology Property to its merged default, the cloned Property replacing it was not properly initialized with pseudo_values. Closes #162.
- Fixes that when a Terminology Property provides pre-defined Values via the popup menu item 'Add Value' and 'Set Value', only empty values were able to be set. Actual values lead to a silent background error. Closes #163.
- Fixes that the gtk.view became out of sync with the underlying data model, virtually breaking the displayed treemodel rendering it unusable for the selected Property until another section was selected. Closes #164.
- The main `editor` now catches exceptions on `undo` to ensure, that the view is properly reset even if an error occurs.
- Does some code cleanup on the side and updates docstrings.

