### PR TITLE
Preparation for version 1.4.3 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,26 @@ matrix:
       python: "3.6"
       sudo: required
       env: CONDA=N
+    - os: linux
+      python: "3.7"
+      dist: xenial
+      sudo: required
+      env: CONDA=N
+    - os: linux
+      python: "3.8"
+      dist: xenial
+      sudo: required
+      env: CONDA=N
+    - os: linux
+      python: "3.7"
+      dist: xenial
+      sudo: required
+      env: CONDA=Y CONDAPY=3.7
+    - os: linux
+      python: "3.8"
+      dist: xenial
+      sudo: required
+      env: CONDA=Y CONDAPY=3.8
 
     - os: osx
       language: generic
@@ -20,6 +40,12 @@ matrix:
     - os: osx
       language: generic
       env: OSXENV=3.6 CONDA=Y CONDAPY=3.6
+    - os: osx
+      language: generic
+      env: OSXENV=3.7 CONDA=Y CONDAPY=3.7
+    - os: osx
+      language: generic
+      env: OSXENV=3.8 CONDA=Y CONDAPY=3.8
 
   include:
     - os: linux
@@ -35,6 +61,16 @@ matrix:
       python: "3.6"
       sudo: required
       env: CONDA=N
+    - os: linux
+      python: "3.7"
+      dist: xenial
+      sudo: required
+      env: CONDA=N
+    - os: linux
+      python: "3.8"
+      dist: xenial
+      sudo: required
+      env: CONDA=N
 
     - os: linux
       python: "2.7"
@@ -48,6 +84,16 @@ matrix:
       python: "3.6"
       sudo: required
       env: CONDA=Y CONDAPY=3.6
+    - os: linux
+      python: "3.7"
+      dist: xenial
+      sudo: required
+      env: CONDA=Y CONDAPY=3.7
+    - os: linux
+      python: "3.8"
+      dist: xenial
+      sudo: required
+      env: CONDA=Y CONDAPY=3.8
 
     - os: osx
       language: generic
@@ -55,6 +101,12 @@ matrix:
     - os: osx
       language: generic
       env: OSXENV=3.6 CONDA=Y CONDAPY=3.6
+    - os: osx
+      language: generic
+      env: OSXENV=3.7 CONDA=Y CONDAPY=3.7
+    - os: osx
+      language: generic
+      env: OSXENV=3.8 CONDA=Y CONDAPY=3.8
 
 
 before_install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ until the next release.
 - Fixes a bug in the `helpers.get_parser_for_file_type` function where it would always return the default parser.
 - Increases the minimal info bar message display time to 10 seconds.
 - Fixes a start-up exception with Python 3.4 on Windows: the cdll.LoadLibrary passes an `ImportError` but still throws a `WindowsError`. Since `WindowsError` is a subclass of `OSError` this one is now used to catch this particular exception.
-
+- Now uses `html.escape` instead of `cgi.escape` for all Python 3 users. See issue #172 for details.
 
 # Version 1.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,24 @@
 Used to document all changes from previous releases and collect changes 
 until the next release.
 
-# Latest changes in master
+# Version 1.4.3
 
 ## Features
-- The TextEditor for editing values of dtype `text` now features
-  'Save' and 'Cancel' buttons.
+- The TextEditor for editing values of dtype `text` now features 'Save' and 'Cancel' buttons.
 
 ## Fixes
 - Fixes saving and loading of files using Windows.
-- Fixes a bug in `helpers.get_parser_for_file_type` 
-  where the file_type would default to `XML` by mistake.
+- Fixes a bug in `helpers.get_parser_for_file_type` where the file_type would default to `XML` by mistake.
 - Various TextEditor bug fixes. See #146
+- With the [python-odml PR #342](https://github.com/G-Node/python-odml/pull/342) the location of the version converter has changed. The `VersionConverter` usage is updated accordingly and the python-odml `save` and `load` functions are now used instead of the more specific respective `ODMLParser` functions. This should make odml-ui more robust towards changes in the odml library.
+- Fixes that when adding a Terminology Property via the context menu in the PropertyView, the added Property was not initialized with pseudo_values, leaving these Properties broken with respect to adding actual values to them. See issue #161 for details.
+- Fixes that when using the popup menu to reset a Terminology Property to its merged default, the cloned Property replacing it was not properly initialized with pseudo_values. See issue #162 for details.
+- Fixes that when a Terminology Property provides pre-defined Values via the popup menu item 'Add Value' and 'Set Value', only empty values were able to be set. Actual values lead to a silent background error. See issue #163 for details.
+- Fixes that the gtk.view became out of sync with the underlying data model, virtually breaking the displayed treemodel rendering it unusable for the selected Property until another section was selected. See issue #164 for details.
+- The main editor now catches exceptions on undo to ensure, that the view is properly reset even if an error occurs.
+- Fixes a bug in the `helpers.get_parser_for_file_type` function where it would always return the default parser.
+- Increases the minimal info bar message display time to 10 seconds.
+- Fixes a start-up exception with Python 3.4 on Windows: the cdll.LoadLibrary passes an `ImportError` but still throws a `WindowsError`. Since `WindowsError` is a subclass of `OSError` this one is now used to catch this particular exception.
 
 
 # Version 1.4.2
@@ -38,6 +45,7 @@ are checked and modified in case the "pseudo_value" attribute is missing.
 - The PropertyView is now properly reset when the last Section is removed from a
     Document making sure there are no stale leftover Properties on display.
 - Fixes errors on 'Undo' and 'Redo' when adding or removing Values.
+
 
 # Version 1.4.1
 

--- a/odmlui/__main__.py
+++ b/odmlui/__main__.py
@@ -51,7 +51,8 @@ def run():
         from ctypes import cdll
         libc = cdll.LoadLibrary("libc.so.6")
         libc.prctl(15, 'odMLEditor', 0, 0, 0)
-    except ImportError:
+    except (ImportError, OSError):
+        # OSError catches a specific 'WindowsError' occurring in py3.4
         pass
 
     from argparse import ArgumentParser

--- a/odmlui/attribute_view.py
+++ b/odmlui/attribute_view.py
@@ -1,6 +1,9 @@
-import cgi
-
 import pygtkcompat
+
+try:  # Python 3
+    from html import escape as html_escape
+except ImportError:  # Python 2
+    from cgi import escape as html_escape
 
 from odml import format as ofmt
 
@@ -71,7 +74,7 @@ class AttributeView(TreeView):
             val = getattr(self._model, self._fmt.map(curr_attr))
             if not isinstance(val, list):
                 if val is not None:
-                    val = cgi.escape(str(val))
+                    val = html_escape(str(val))
 
                 # Exclude property attributes that are displayed in the
                 # PropertyView window.

--- a/odmlui/info.json
+++ b/odmlui/info.json
@@ -1,15 +1,15 @@
 {
-  "VERSION": "1.4.2",
+  "VERSION": "1.4.3",
   "AUTHOR": "Shubham Dighe, Hagen Fritsch, Christian Kellner, Jan Grewe, Achilleas Koutsou, Michael Sonntag",
-  "COPYRIGHT": "(c) 2011-2018, German Neuroinformatics Node",
+  "COPYRIGHT": "(c) 2011-2020, German Neuroinformatics Node",
   "CONTACT": "dev@g-node.org",
   "HOMEPAGE": "https://github.com/G-Node/odml-ui",
   "CLASSIFIERS": [
     "Development Status :: 4 - Beta",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
     "Topic :: Scientific/Engineering",
     "Intended Audience :: Science/Research",
     "Intended Audience :: End Users/Desktop",

--- a/odmlui/info.json
+++ b/odmlui/info.json
@@ -10,6 +10,7 @@
     "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
     "Topic :: Scientific/Engineering",
     "Intended Audience :: Science/Research",
     "Intended Audience :: End Users/Desktop",

--- a/odmlui/treemodel/generic_iter.py
+++ b/odmlui/treemodel/generic_iter.py
@@ -1,5 +1,9 @@
-import cgi
 import sys
+
+try:  # Python 3
+    from html import escape as html_escape
+except ImportError:  # Python 2
+    from cgi import escape as html_escape
 
 
 class GenericIter(object):
@@ -28,7 +32,7 @@ class GenericIter(object):
     @staticmethod
     def escape(value):
         """escape html for use in marked up cellrenderers"""
-        value = cgi.escape(value) if value is not None else ''
+        value = html_escape(value) if value is not None else ''
         if value and GenericIter.is_python2:
             value = value.encode('utf-8')
         return value

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setup(
     include_package_data=True,
     data_files=data_files,
     long_description=description_text,
+    long_description_content_type="text/markdown",
     classifiers=CLASSIFIERS,
     license="BSD",
     entry_points={"gui_scripts": ["odmlui = odmlui.__main__:run []"]}

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ packages = [
     "odmlui.treemodel"
 ]
 
-install_req = ["odml>=1.4.2"]
+install_req = ["odml>=1.4.4"]
 
 data_files = [("share/pixmaps", glob.glob(os.path.join("images", "*"))),
               ("share/odmlui", ["LICENSE"])]


### PR DESCRIPTION
This PR prepares for the release of version 1.4.3. It

- this PR depends on the [python-odml PR #348](https://github.com/G-Node/python-odml/pull/348) and updates the odml library dependency accordingly.
- updates the release number, copyright date and the classifiers in `info.json`. It also removes the `Python 2.7` classifier since Python 2 has reached end of life and future versions of odML will drop Python 2 compatibility.
- adds all changes since v1.4.2 to the `CHANGELOG`.
- fixes #172 (cgi.escape has been removed with Python 3.8)
- fixes an uncaught exception when opening odml-ui with Python 3.4 under Windows. The cdll.LoadLibrary passes an `ImportError` but still throws a `WindowsError`. Since `WindowsError` is a subclass of `OSError` this one is now used to catch this particular exception.
