### PR TITLE
Property Values Text

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ language: python
 matrix:
   allow_failures:
     - os: linux
+      python: "2.7_with_system_site_packages"
+      sudo: required
+      env: CONDA=N
+    - os: linux
       python: "3.5"
       sudo: required
       env: CONDA=N
@@ -23,6 +27,10 @@ matrix:
       dist: xenial
       sudo: required
       env: CONDA=N
+    - os: linux
+      python: "2.7"
+      sudo: required
+      env: CONDA=Y CONDAPY=2.7
     - os: linux
       python: "3.7"
       dist: xenial
@@ -116,8 +124,8 @@ before_install:
 
 install:
   - if [[ "$CONDA" == "Y" ]]; then
-      export PATH="$HOME/miniconda/bin:$PATH";
-      source activate condaenv;
+    export PATH="$HOME/miniconda/bin:$PATH";
+    source activate condaenv;
     fi
   - which python
   - python setup.py install

--- a/odmlui/editor.py
+++ b/odmlui/editor.py
@@ -429,8 +429,12 @@ class EditorWindow(gtk.Window):
         """
         page = gtk.Label()
         # welcome text
-        text = """<span size="x-large" weight="bold">Welcome to odML-Editor</span>\n\n
-                   Now go ahead and <a href="#new">create a new document</a>."""
+        text = """<span size="x-large" weight="bold">Welcome to odML-Editor</span>\n\n"""
+        # show python 2 deprecation warning
+        if not sys.version_info > (3, 0):
+            text += """<span foreground="red">DeprecationWarning: Python 2 has been deprecated.\n"""
+            text += """odML support for Python 2 will be dropped August 2020.</span>\n\n"""
+        text += """Now go ahead and <a href="#new">create a new document</a>."""
         for curr_action in self.welcome_disabled_actions:
             self.enable_action(curr_action, False)
 

--- a/odmlui/message_dialog.py
+++ b/odmlui/message_dialog.py
@@ -52,11 +52,19 @@ class DecisionDialog(gtk.MessageDialog):
     - Secondary message
     - OK and Cancel button
     """
-    def __init__(self, parent, title, message, sub_message):
-        gtk.MessageDialog.__init__(self)
-        self.parent = parent
+
+    def __init__(self, parent, title, primary_msg, secondary_msg):
+        super(DecisionDialog, self).__init__()
         self.title = title
-        self.set_property("text", message)
-        self.set_property("secondary-text", sub_message)
+        self.set_property('text', primary_msg)
+        self.set_property('secondary-text', secondary_msg)
+        self.set_transient_for(parent)
         self.add_button("Cancel", gtk.ResponseType.CANCEL)
         self.add_button("Ok", gtk.ResponseType.OK)
+
+    def display(self):
+        response = self.run()
+        self.destroy()
+        if response == gtk.ResponseType.OK:
+            return True
+        return False

--- a/odmlui/property_view.py
+++ b/odmlui/property_view.py
@@ -22,6 +22,7 @@ from .treemodel import property_model, value_model
 from .dnd.odmldrop import OdmlDrag, OdmlDrop
 from .dnd.targets import ValueDrop, PropertyDrop, SectionDrop
 from .dnd.text import TextDrag, TextDrop, TextGenericDropForPropertyTV
+from .message_dialog import DecisionDialog
 
 pygtkcompat.enable()
 pygtkcompat.enable_gtk(version='3.0')
@@ -196,6 +197,16 @@ class PropertyView(TerminologyPopupTreeView):
         # Do not replace multiple values with pseudo_value placeholder text.
         if first_row_of_multi and is_value_column and new_text == "<multi>":
             return
+
+        # Assure that text is not accidentally overwritten with abbreviation
+        if is_value_column and prop.dtype == "text" and "[...]" in new_text:
+            assurance = DecisionDialog(gtk.Window(), "Text",
+                                       "Abbreviation Detected",
+                                       "Editing text without the text editor "
+                                       "overwrites the original "
+                                       "value with its abbreviated form ([...]).")
+            if not assurance.display():
+                return
 
         # If we edit another attribute (e.g. unit), set this
         # for all values of this property.

--- a/odmlui/property_view.py
+++ b/odmlui/property_view.py
@@ -226,6 +226,9 @@ class PropertyView(TerminologyPopupTreeView):
 
                 prop = prop.pseudo_values[0]
 
+            if first_row and column_name == "uncertainty":
+                new_text = new_text.replace(",", ".")
+
             cmd = commands.ChangeValue(object=prop, attr=column_name, new_value=new_text)
 
         if cmd:


### PR DESCRIPTION
This PR

- Replaces Comma with Dot, when editing Uncertainty. Closes #149 
- Issues a warning, if a value of dtype text would be overwritten with its abbreviated form. Closes #157 
- Adds a python2 deprecation warning on Welcome. Closes #174 