### PR TITLE
Value Reordering

### DIFF
--- a/odmlui/commands.py
+++ b/odmlui/commands.py
@@ -102,8 +102,7 @@ class ChangeValue(Command):
             # execute failed
             return
 
-        for attr in self.attr:
-            setattr(self.object, attr, self.old_value[attr])
+        setattr(self.object, self.attr[0], self.old_value[self.attr[0]])
 
 
 class AppendValue(Command):

--- a/odmlui/dnd/targets.py
+++ b/odmlui/dnd/targets.py
@@ -35,8 +35,10 @@ class GenericDrop(ActionDrop):
 class ValueDrop(GenericDrop):
     def odml_can_drop(self, action, dst, position, obj):
         """
-        can only move/copy into Properties
+        can only move/copy into same Property and not onto <multi> field
         """
+        if obj and (obj.parent != dst or position == -1):
+            return False
         if action.link:
             return False
 

--- a/odmlui/treemodel/event.py
+++ b/odmlui/treemodel/event.py
@@ -257,6 +257,23 @@ def remove_value(prop, pseudo):
     prop.values = cp_val
 
 
+def reorder_value(prop, value, new_index):
+    """
+    Reorder a property value and its corresponding pseudo_value.
+    :param prop: odml Property augmented to fit odml-ui.
+    :param value: odmlui.treemodel.ValueModel.Value.
+    :param new_index: new position of the value.
+    """
+
+    v_list = prop.values
+    old_index = value._index
+    new_order = list(range(len(v_list)))
+    new_order.insert(new_index, old_index)
+    del new_order[old_index if new_index > old_index else (old_index+1)]
+    new_v_list = [v_list[i] for i in new_order]
+    prop.values = new_v_list
+
+
 # create a separate global Event listeners for each class
 # and provide ModificationNotifier Capabilities
 name = "event"

--- a/odmlui/treemodel/event.py
+++ b/odmlui/treemodel/event.py
@@ -231,7 +231,9 @@ class ModificationNotifier(ChangeHandlable):
         self.__fire_change("insert", obj, func)
 
     def _reorder(self, childlist, value, new_index):
-        func = lambda: reorder_value(self.parent, value, new_index)
+        func = lambda: super(ModificationNotifier, self)._reorder(childlist, new_index)
+        if hasattr(self, "pseudo_values"):
+            func = lambda: reorder_value(self.parent, value, new_index)
         return self.__fire_change("reorder", (childlist, value, new_index), func)
 
 

--- a/odmlui/treemodel/event.py
+++ b/odmlui/treemodel/event.py
@@ -230,9 +230,9 @@ class ModificationNotifier(ChangeHandlable):
         func = lambda: super(ModificationNotifier, self).insert(position, obj)
         self.__fire_change("insert", obj, func)
 
-    def _reorder(self, childlist, new_index):
-        func = lambda: super(ModificationNotifier, self)._reorder(childlist, new_index)
-        return self.__fire_change("reorder", (childlist, new_index), func)
+    def _reorder(self, childlist, value, new_index):
+        func = lambda: reorder_value(self.parent, value, new_index)
+        return self.__fire_change("reorder", (childlist, value, new_index), func)
 
 
 def remove_value(prop, pseudo):

--- a/odmlui/treemodel/tree_model.py
+++ b/odmlui/treemodel/tree_model.py
@@ -187,7 +187,10 @@ class TreeModel(gtk.GenericTreeModel):
 
         TODO figure out how to handle recursive removals
         """
-        self.row_deleted(old_path)
+        if hasattr(parent, "values") and len(parent.values) == 1:
+            self.row_deleted((old_path[0], (old_path[1]+1) % 2))
+        else:
+            self.row_deleted(old_path)
         iter = self.get_node_iter(parent)
 
         # We need to check if the old path is already the very root.

--- a/odmlui/treemodel/tree_model.py
+++ b/odmlui/treemodel/tree_model.py
@@ -228,15 +228,15 @@ class TreeModel(gtk.GenericTreeModel):
         a rows_reordered call
         """
         if context.pre_change and not hasattr(context, "neworder"):
-            (childlist, new_index) = context.val
-            old_index = childlist.index(context.obj)
-            res = list(range(len(childlist)))
-            res.insert(new_index if new_index < old_index else new_index+1, old_index)
+            (child_list, value, new_index) = context.val
+            old_index = child_list.index(getattr(value, "value"))
+            res = list(range(len(child_list)))
+            res.insert(new_index, old_index)
             del res[old_index if new_index > old_index else (old_index+1)]
-            context.neworder = res
+            context.new_order = res
         if context.post_change:
             iter = self.get_node_iter(context.obj.parent)
             path = self.get_path(iter)
             if not path and context.obj.parent is not self._section:
                 return  # not our deal
-            self.rows_reordered(path, iter, context.neworder)
+            self.rows_reordered(path, iter, context.new_order)

--- a/odmlui/treemodel/value_model.py
+++ b/odmlui/treemodel/value_model.py
@@ -159,7 +159,7 @@ class Value(BaseObject, ValueNode, event.ModificationNotifier):
         return "(%d bytes)" % len(self._value)
 
     def reorder(self, new_index):
-        return self._reorder(self.parent.values, new_index)
+        return self._reorder(self.parent.values, self, new_index)
 
     def clone(self):
         obj = BaseObject.clone(self)


### PR DESCRIPTION
This PR:

- Fixes the error on multi value reordering. Closes #141 
- Fixes the error when deleting empty/the first of two multi values. Closes #137 
- Prohibits dropping values on different properties other than the parent of the dragged value. Closes #143 
- Removes `AttributeError` when undoing a change to property pseudo value. Closes #138 