### PR TITLE
Preparation for version 1.4.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 Used to document all changes from previous releases and collect changes 
 until the next release.
 
+# Version 1.4.4
+
+# Requirement update
+- The release updates the python-odml library requirement to version 1.5.1.
+
+# Minor changes and updates
+- When using Python 2 a popup with a deprecation warning message is displayed. See PR #175 and issue #174 for details.
+- A warning is issued when a Property.Value of `dtype=text` would be overwritten with the abbreviated list display text by accident. See PR #175 and issue #157 for details.
+- A function is added to the "Edit" menu to refresh the terminology cache. See PR #178 and issue #118 for details.
+
+# Fixes
+- Fixes broken Properties reorder behavior. See issue PR #180 and issue #142 for details.
+- Fixes an error on multi value reorder behavior. See PR #179 and issue #141 for details.
+- Fixes an error on multi value removal. See PR #179 and issue #137 for details.
+- Fixes multi value loss when dragging it to another Property by prohibiting value transferal to another Property. See PR #179 and issue #143 for details.
+- Fixes a background AttibuteError when undoing a Propert.value change. See PR #179 and issue #138 for details.
+- Fixes system dependent automatic replacement of comma with a dot when editing a value uncertainty. See PR #175 and issue #149 for details.
+
 # Version 1.4.3
 
 ## Features

--- a/odmlui/info.json
+++ b/odmlui/info.json
@@ -1,5 +1,5 @@
 {
-  "VERSION": "1.4.3",
+  "VERSION": "1.4.4",
   "AUTHOR": "Shubham Dighe, Hagen Fritsch, Christian Kellner, Jan Grewe, Achilleas Koutsou, Michael Sonntag",
   "COPYRIGHT": "(c) 2011-2020, German Neuroinformatics Node",
   "CONTACT": "dev@g-node.org",

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ packages = [
     "odmlui.treemodel"
 ]
 
-install_req = ["odml>=1.4.4"]
+install_req = ["odml>=1.5.1"]
 
 data_files = [("share/pixmaps", glob.glob(os.path.join("images", "*"))),
               ("share/odmlui", ["LICENSE"])]


### PR DESCRIPTION
This PR prepares for the release of version 1.4.4.

The package up to the latest commit in this PR has been packaged and uploaded to TestPyPI and has been tested with the required odml release from TestPyPI and the odmltables plugin as well.

The PR itself
- changes the required odml library since some of the fixes introduced in previous PRs depend on an odml version >= 1.5.0.
- updates the version number to 1.4.4
- updates the CHANGELOG including all changes since the 1.4.3 release.

CI tests should pass once odml PR [#401](https://github.com/G-Node/python-odml/pull/401) has been merged and the package uploaded to PyPI proper.