### PR TITLE
Introducing github actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,8 @@
 name: run-tests
 on:
-  # test cron by running it once a day at 01:00
+  # Run one build a month at 01:00
   schedule:
-  - cron:  '0 1 * * *'
+  - cron:  '0 0 1 * *'
   push:
     branches:
       - master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,57 @@
+name: run-tests
+on:
+  # test cron by running it once a day at 01:00
+  schedule:
+  - cron:  '0 1 * * *'
+  push:
+    branches:
+      - master
+      - dev
+  pull_request:
+    branches:
+      - master
+jobs:
+  run-conda-test:
+    name: Running tests using miniconda
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash -l {0}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: [3.6, 3.7, 3.8, 3.9]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: deptest-${{ matrix.python-version }}
+          python-version: ${{ matrix.python-version }}
+          channels: conda-forge,pkgw-forge
+      - name: Show conda details
+        run: |
+          conda info
+          conda list
+          which python
+          conda --version
+      - name: Install Linux conda dependencies
+        if:  matrix.os == 'ubuntu-latest'
+        run: |
+          conda install -c pkgw/label/superseded gtk3
+          conda install -c conda-forge pygobject
+          conda install -c conda-forge gdk-pixbuf
+          conda install -c pkgw-forge adwaita-icon-theme
+      - name: Install MacOS conda dependencies
+        if:  matrix.os == 'macos-latest'
+        run: |
+          conda install -c conda-forge gtk3
+          conda install -c conda-forge pygobject
+          conda install -c conda-forge gdk-pixbuf
+          conda install -c conda-forge adwaita-icon-theme
+      - name: Install Python dependencies
+        run: |
+          python setup.py install
+          pip install pytest
+      - name: Run tests
+        run: |
+          pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,118 +4,13 @@ dist: trusty
 language: python
 
 matrix:
-  allow_failures:
-    - os: linux
-      python: "2.7_with_system_site_packages"
-      sudo: required
-      env: CONDA=N
-    - os: linux
-      python: "3.5"
-      sudo: required
-      env: CONDA=N
-    - os: linux
-      python: "3.6"
-      sudo: required
-      env: CONDA=N
-    - os: linux
-      python: "3.7"
-      dist: xenial
-      sudo: required
-      env: CONDA=N
-    - os: linux
-      python: "3.8"
-      dist: xenial
-      sudo: required
-      env: CONDA=N
-    - os: linux
-      python: "2.7"
-      sudo: required
-      env: CONDA=Y CONDAPY=2.7
-    - os: linux
-      python: "3.7"
-      dist: xenial
-      sudo: required
-      env: CONDA=Y CONDAPY=3.7
-    - os: linux
-      python: "3.8"
-      dist: xenial
-      sudo: required
-      env: CONDA=Y CONDAPY=3.8
-
-    - os: osx
-      language: generic
-      env: OSXENV=2.7 CONDA=Y CONDAPY=2.7
-    - os: osx
-      language: generic
-      env: OSXENV=3.6 CONDA=Y CONDAPY=3.6
-    - os: osx
-      language: generic
-      env: OSXENV=3.7 CONDA=Y CONDAPY=3.7
-    - os: osx
-      language: generic
-      env: OSXENV=3.8 CONDA=Y CONDAPY=3.8
 
   include:
     - os: linux
-      python: "2.7_with_system_site_packages"
-      sudo: required
-      env: CONDA=N
-
-    - os: linux
-      python: "3.5"
-      sudo: required
-      env: CONDA=N
-    - os: linux
-      python: "3.6"
-      sudo: required
-      env: CONDA=N
-    - os: linux
-      python: "3.7"
-      dist: xenial
-      sudo: required
-      env: CONDA=N
-    - os: linux
-      python: "3.8"
-      dist: xenial
-      sudo: required
-      env: CONDA=N
-
-    - os: linux
-      python: "2.7"
-      sudo: required
-      env: CONDA=Y CONDAPY=2.7
-    - os: linux
-      python: "3.5"
-      sudo: required
-      env: CONDA=Y CONDAPY=3.5
-    - os: linux
-      python: "3.6"
-      sudo: required
-      env: CONDA=Y CONDAPY=3.6
-    - os: linux
-      python: "3.7"
-      dist: xenial
-      sudo: required
-      env: CONDA=Y CONDAPY=3.7
-    - os: linux
       python: "3.8"
       dist: xenial
       sudo: required
       env: CONDA=Y CONDAPY=3.8
-
-    - os: osx
-      language: generic
-      env: OSXENV=2.7 CONDA=Y CONDAPY=2.7
-    - os: osx
-      language: generic
-      env: OSXENV=3.6 CONDA=Y CONDAPY=3.6
-    - os: osx
-      language: generic
-      env: OSXENV=3.7 CONDA=Y CONDAPY=3.7
-    - os: osx
-      language: generic
-      env: OSXENV=3.8 CONDA=Y CONDAPY=3.8
-
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then bash resources/install_osx_virtualenv.sh; fi

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/G-Node/odml-ui.svg?branch=master)](https://travis-ci.org/G-Node/odml-ui)
+[![gh actions tests](https://github.com/G-Node/odml-ui/workflows/run-tests/badge.svg?branch=master)](https://github.com/G-Node/odml-ui/actions)
 [![PyPI version](https://img.shields.io/pypi/v/odml-ui.svg)](https://pypi.org/project/odML-UI/)
 
 
@@ -11,7 +11,7 @@ have a look at the documentation available on the [git-scm website](https://git-
 
 ## Breaking changes
 
-odML Version 1.4 introduced breaking format and API changes compared to the previous
+odML Version 1.4+ introduced breaking format and API changes compared to the previous
 versions of odML. Files saved in a previous format version can be automatically
 converted into the new format via "File - Import". The import will create a new file
 and will not overwrite the original file.
@@ -44,31 +44,31 @@ The odML-Editor makes use of the Gtk 3+ library for the GUI, and the
 `python-odml` library. The following dependencies need to be installed 
 for the odML-Editor.
 
-* Python 2.7+ or Python 3.4+
-* odml v1.4  `(pip install odml)`
+* Python 3.6+
+* odml v1.5.1+  `(pip install odml)`
+
+An installation using the conda package manager is highly recommended. Please also note, that Python 2 is no longer supported. 
 
 
 ### For Ubuntu-based distributions
 
 * `sudo apt-get install libgtk-3-0`
 * `sudo apt-get install gobject-introspection`
-* For Python 3, `sudo apt-get install python3-gi`
-* For Python 2, `sudo apt-get install python-gi`
+* `sudo apt-get install python3-gi`
 
 
 ### For Fedora-based distributions
 
 * `sudo dnf install gtk3`
 * `sudo dnf install pygobject3`
-* For Python 3, `sudo dnf install python3-gobject`
-* For Python 2, `sudo dnf install python-gobject`
+* `sudo dnf install python3-gobject`
 
 
 ### Anaconda Dependencies
 
 Anaconda environments require only the following packages before installing the odML-Editor:
 
-* Python 2.7+ or Python 3.4+.
+* Python 3.6+.
 * Install the following packages in the following order:
 
         conda install -c pkgw/label/superseded gtk3
@@ -95,10 +95,10 @@ https://conda.io/docs/user-guide/tasks/manage-environments.html#macos-linux-save
 
 ### macOS using homebrew
 
-For Python 2 (Python 3)
+For Python 3
 
-* `brew install gtk+ (gtk+3)`
-* `brew install pygobject (pygobject3)`
+* `brew install gtk+3`
+* `brew install pygobject3`
 * `brew install gnome-icon-theme`
 * `brew install gobject-introspection`
 


### PR DESCRIPTION
Travis still accepts jobs, but it is slow and its unsure how long it will be available. Therefore we are migrating to github actions.

The current github actions setup runs all available tests in a [ubuntu, macos], Python [3.6, 3.7, 3.8, 3.9] matrix.

The PR also
-  reduces the travis setup to a single Linux build for the time being.
- updates the README file, replacing the travis with a github actions badge for tests and removing Python 2 dependency descriptions since the odml core library does not support Python 2 any longer.
